### PR TITLE
Remove django-pgschemas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==4.1.0
 psycopg2==2.9.3
-django-pgschemas==0.10.0
 gunicorn==20.1.0
 whitenoise==6.2.0


### PR DESCRIPTION
This removes the `django-pgschemas` requirement, as that module will not be used.