### PR TITLE
SYS-982: Support MARC record retrieval in view

### DIFF
--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -4,16 +4,27 @@ from django.shortcuts import render
 from django.http.request import HttpRequest # for code completion
 from django.http.response import HttpResponse
 from .forms import VoyArchiveForm
+from .views_utils import *
+
 
 logger = logging.getLogger(__name__)
 
 
-def search(request: HttpRequest):
+def search(request: HttpRequest) -> None:
     if request.method == 'POST':
         form = VoyArchiveForm(request.POST)
         if form.is_valid():
             # Do stuff, using form.cleaned_data['search_type'] and form.cleaned_data['search_term']
             logger.info(f'Form data: {form.cleaned_data}')
+            search_type = form.cleaned_data['search_type']
+            search_term = form.cleaned_data['search_term']
+            if search_type == 'AUTH_ID':
+                marc_record = get_auth_record(search_term)
+            elif search_type == 'BIB_ID':
+                marc_record = get_bib_record(search_term)
+            elif search_type == 'MFHD_ID':
+                marc_record = get_mfhd_record(search_term)
+
             return render(request, 'voyager_archive/search.html', {'form': form})
     else:
         form = VoyArchiveForm()

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,0 +1,14 @@
+from django.shortcuts import get_object_or_404
+from .models import AuthRecord, BibRecord, MfhdRecord
+
+
+def get_auth_record(auth_id: int) -> AuthRecord:
+    return get_object_or_404(AuthRecord, auth_id=auth_id)
+
+
+def get_bib_record(bib_id: int) -> BibRecord:
+    return get_object_or_404(BibRecord, bib_id=bib_id)
+
+
+def get_mfhd_record(mfhd_id: int) -> MfhdRecord:
+    return get_object_or_404(MfhdRecord, mfhd_id=mfhd_id)


### PR DESCRIPTION
This PR adds the ability to retrieve MARC records (retrieve only, not display).

I want to keep complex / lengthy code out of the `search` view, by moving it to `views_utils.py` and including those functions into `views.py`.

This also uses Django's `get_object_or_404()` shortcut, which I think is more appropriate than try/catch for `Model.DoesNotExist`.  If a search finds nothing, the 404 page displays.

Not much to test here.  The sample data contains just a few records; searching for these should find something, while other MARC searches will get a 404:
* AUTH_ID: 3228675
* BIB_ID: 9411434
* MFHD_ID: 12507598
