### PR TITLE
Sys 1009/marc record display improvements

### DIFF
--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -28,3 +28,11 @@
   table.data-display tr:nth-child(even) {
     background-color: #f2f2f2;
   }
+
+  .indicators {
+    color: green
+  }
+  
+  .subfield {
+    color: blue
+  }

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -33,6 +33,6 @@
     color: green
   }
   
-  .subfield {
+  .delimiter {
     color: blue
   }

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -11,22 +11,39 @@
 </form>
 <hr/>
 
-{% comment %}
-Raw Marc dump
-{% endcomment %}
-
 Data for form values:
 {% for key, val in form.cleaned_data.items %}
 <p>{{ key }} = {{ val }} </p>
 {% endfor %}
 
-<!-- will clean up to clean table -->
-Marc values:
-<p>{{ marc_record.leader }}</p>
 
-{% for field in marc_record.fields %}
-{{ field.tag }}, {{ field.indicators }}, {{ field.subfields }}
-<br>
-{% endfor %}
+<div class="row">
+    <div class="column">
+        <h2>Record Leader: {{ marc_record.leader }}</h1>
+        <table class="data-display">
+            <tr>
+                <th>Tag</th>
+                <th>Indicators</th>
+                <th>Data and Subfields</th>
+            </tr>
+            {% for field in marc_record.fields %}
+            <tr>
+                <td>{{ field.tag }}</td>
+                <td><span class='indicators'>{{ field.indicators }}</span></td>
+                <td>
+                    {{ field.data }}
+                    {% for delimiter, values in field.subfields.items %}
+                        <span class='subfield'>${{ delimiter }}</span>
+                        {% for value in values %}
+                            {{ value }}
+                        {% endfor %}
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+</div>
+
 
 {% endblock %}

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -11,12 +11,6 @@
 </form>
 <hr/>
 
-Data for form values:
-{% for key, val in form.cleaned_data.items %}
-<p>{{ key }} = {{ val }} </p>
-{% endfor %}
-
-
 <div class="row">
     <div class="column">
         <h2>Record Leader: {{ marc_record.leader }}</h1>

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -20,9 +20,13 @@ Data for form values:
 <p>{{ key }} = {{ val }} </p>
 {% endfor %}
 
+<!-- will clean up to clean table -->
 Marc values:
-{% for field in marc_record %}
-<p>{{ field }}</p>
+<p>{{ marc_record.leader }}</p>
+
+{% for field in marc_record.fields %}
+{{ field.tag }}, {{ field.indicators }}, {{ field.subfields }}
+<br>
 {% endfor %}
 
 {% endblock %}

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -13,23 +13,21 @@
 
 <div class="row">
     <div class="column">
-        <h2>Record Leader: {{ marc_record.leader }}</h1>
+        <h4>Record Leader: {{ marc_record.leader }}</h4>
         <table class="data-display">
-            <tr>
-                <th>Tag</th>
-                <th>Indicators</th>
-                <th>Data and Subfields</th>
-            </tr>
             {% for field in marc_record.fields %}
             <tr>
                 <td>{{ field.tag }}</td>
-                <td><span class='indicators'>{{ field.indicators }}</span></td>
+                <td><span class='indicators'>
+                    {{ field.indicator1|default:"_" }}
+                    {{ field.indicator2|default:"_" }}
+                    </span>
+                </td>
                 <td>
                     {{ field.data }}
                     {% for delimiter, values in field.subfields.items %}
-                        <span class='subfield'>${{ delimiter }}</span>
                         {% for value in values %}
-                            {{ value }}
+                            <span class='delimiter'>${{ delimiter }}</span> {{ value }}
                         {% endfor %}
                     {% endfor %}
                 </td>

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -19,8 +19,8 @@
             <tr>
                 <td>{{ field.tag }}</td>
                 <td><span class='indicators'>
-                    {{ field.indicator1|default:"_" }}
-                    {{ field.indicator2|default:"_" }}
+                    {{ field.indicator1 }}
+                    {{ field.indicator2 }}
                     </span>
                 </td>
                 <td>

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -3,25 +3,25 @@ from pymarc import Record
 from .models import AuthRecord, BibRecord, MfhdRecord, ItemView
 
 
-def get_auth_record(auth_id: int) -> list:
+def get_auth_record(auth_id: int) -> dict:
     marc_text = get_object_or_404(AuthRecord, auth_id=auth_id).auth_record
 
     return get_marc_fields(marc_text)
 
 
-def get_bib_record(bib_id: int) -> list:
+def get_bib_record(bib_id: int) -> dict:
     marc_text = get_object_or_404(BibRecord, bib_id=bib_id).bib_record
 
     return get_marc_fields(marc_text)
 
 
-def get_mfhd_record(mfhd_id: int) -> list:
+def get_mfhd_record(mfhd_id: int) -> dict:
     marc_text = get_object_or_404(MfhdRecord, mfhd_id=mfhd_id).mfhd_record
 
     return get_marc_fields(marc_text)
 
 
-def get_marc_fields(marc_text: str) -> list:
+def get_marc_fields(marc_text: str) -> dict:
     byte_obj = marc_text.encode("utf-8")
     marc_record = Record(data=byte_obj)
     marc_fields = marc_record.get_fields()
@@ -38,8 +38,8 @@ def get_marc_fields(marc_text: str) -> list:
             tmp_rec_dict["data"] = field.data
 
         if hasattr(field, "indicator1"):
-            tmp_rec_dict["indicator1"] = str.strip(field.indicator1)
-            tmp_rec_dict["indicator2"] = str.strip(field.indicator2)
+            tmp_rec_dict["indicator1"] = field.indicator1.replace(" ", "_")
+            tmp_rec_dict["indicator2"] = field.indicator2.replace(" ", "_")
 
         try:
             subfield_dict = {}

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404
-from pymarc import Record, Field
+from pymarc import Record
 from .models import AuthRecord, BibRecord, MfhdRecord, ItemView
 
 
@@ -8,41 +8,44 @@ def get_auth_record(auth_id: int) -> list:
 
     return get_marc_fields(marc_text)
 
+
 def get_bib_record(bib_id: int) -> list:
     marc_text = get_object_or_404(BibRecord, bib_id=bib_id).bib_record
 
     return get_marc_fields(marc_text)
 
+
 def get_mfhd_record(mfhd_id: int) -> list:
     marc_text = get_object_or_404(MfhdRecord, mfhd_id=mfhd_id).mfhd_record
-   
+
     return get_marc_fields(marc_text)
 
+
 def get_marc_fields(marc_text: str) -> list:
-    byte_obj = marc_text.encode('utf-8')
+    byte_obj = marc_text.encode("utf-8")
     marc_record = Record(data=byte_obj)
     marc_fields = marc_record.get_fields()
 
     marc_field_list = []
     marc_record_dict = {}
-    marc_record_dict['leader'] = marc_record.leader
+    marc_record_dict["leader"] = marc_record.leader
 
     for field in marc_fields:
 
         tmp_rec_dict = {}
-        tmp_rec_dict['tag'] = field.tag
-        if hasattr(field, 'data'):
-            tmp_rec_dict['data'] = field.data
-        
-        if hasattr(field, 'indicator1'):
-            tmp_rec_dict['indicators'] = f'{field.indicator1} {field.indicator2}'
-        
+        tmp_rec_dict["tag"] = field.tag
+        if hasattr(field, "data"):
+            tmp_rec_dict["data"] = field.data
+
+        if hasattr(field, "indicator1"):
+            tmp_rec_dict["indicators"] = f"{field.indicator1} {field.indicator2}"
+
         try:
             subfield_dict = {}
             subfield_default_dict = field.subfields_as_dict()
             for delim in subfield_default_dict.keys():
                 subfield_dict[delim] = subfield_default_dict[delim]
-            tmp_rec_dict['subfields'] = subfield_dict
+            tmp_rec_dict["subfields"] = subfield_dict
 
         except Exception as e:
             # If subfields don't exist an exception is thrown
@@ -50,9 +53,10 @@ def get_marc_fields(marc_text: str) -> list:
 
         marc_field_list.append(tmp_rec_dict)
 
-    marc_record_dict['fields'] = marc_field_list
+    marc_record_dict["fields"] = marc_field_list
 
     return marc_record_dict
+
 
 def get_item(item_barcode: str) -> ItemView:
     item = get_object_or_404(ItemView, item_barcode=item_barcode)

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -38,7 +38,8 @@ def get_marc_fields(marc_text: str) -> list:
             tmp_rec_dict["data"] = field.data
 
         if hasattr(field, "indicator1"):
-            tmp_rec_dict["indicators"] = f"{field.indicator1} {field.indicator2}"
+            tmp_rec_dict["indicator1"] = str.strip(field.indicator1)
+            tmp_rec_dict["indicator2"] = str.strip(field.indicator2)
 
         try:
             subfield_dict = {}

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404
-from pymarc import Record
+from pymarc import Record, Field
 from .models import AuthRecord, BibRecord, MfhdRecord, ItemView
 
 
@@ -23,7 +23,7 @@ def get_marc_fields(marc_text: str) -> list:
     marc_record = Record(data=byte_obj)
     marc_fields = marc_record.get_fields()
 
-    marc_record_list = []
+    marc_field_list = []
     marc_record_dict = {}
     marc_record_dict['leader'] = marc_record.leader
 
@@ -31,13 +31,26 @@ def get_marc_fields(marc_text: str) -> list:
 
         tmp_rec_dict = {}
         tmp_rec_dict['tag'] = field.tag
+        if hasattr(field, 'data'):
+            tmp_rec_dict['data'] = field.data
+        
         if hasattr(field, 'indicator1'):
             tmp_rec_dict['indicators'] = f'{field.indicator1} {field.indicator2}'
-        tmp_rec_dict['subfields'] = field.format_field
+        
+        try:
+            subfield_dict = {}
+            subfield_default_dict = field.subfields_as_dict()
+            for delim in subfield_default_dict.keys():
+                subfield_dict[delim] = subfield_default_dict[delim]
+            tmp_rec_dict['subfields'] = subfield_dict
 
-        marc_record_list.append(tmp_rec_dict)
+        except Exception as e:
+            # If subfields don't exist an exception is thrown
+            pass
 
-    marc_record_dict['fields'] = marc_record_list
+        marc_field_list.append(tmp_rec_dict)
+
+    marc_record_dict['fields'] = marc_field_list
 
     return marc_record_dict
 

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -23,7 +23,23 @@ def get_marc_fields(marc_text: str) -> list:
     marc_record = Record(data=byte_obj)
     marc_fields = marc_record.get_fields()
 
-    return marc_fields
+    marc_record_list = []
+    marc_record_dict = {}
+    marc_record_dict['leader'] = marc_record.leader
+
+    for field in marc_fields:
+
+        tmp_rec_dict = {}
+        tmp_rec_dict['tag'] = field.tag
+        if hasattr(field, 'indicator1'):
+            tmp_rec_dict['indicators'] = f'{field.indicator1} {field.indicator2}'
+        tmp_rec_dict['subfields'] = field.format_field
+
+        marc_record_list.append(tmp_rec_dict)
+
+    marc_record_dict['fields'] = marc_record_list
+
+    return marc_record_dict
 
 def get_item(item_barcode: str) -> ItemView:
     item = get_object_or_404(ItemView, item_barcode=item_barcode)


### PR DESCRIPTION
PR for improved marc record display, some minor additions of css. To test display, submit form with existing marc record id, in the dev database, an existing sample is authority record id is `3228675`

The fields should be displayed in a tabular format, with columns of tag, indicators and data/subfields. The leader is presented as a header. 

Formatting was done via Black, a notable difference is double quotes rather than single in some cases. I can use other formatters for consistency if preferred. 

![Screen Shot 2022-10-05 at 4 29 42 PM](https://user-images.githubusercontent.com/1273423/194182677-43761424-c984-4a12-b859-7aadee93baf1.png)
