### PR TITLE
SYS-1001: Display Vendors

### DIFF
--- a/sql_support/sample_data.sql
+++ b/sql_support/sample_data.sql
@@ -421,3 +421,27 @@ VE	Vendor
 \.
 
 COMMIT;
+
+BEGIN;
+
+SET client_encoding TO 'UTF8';
+SET synchronous_commit TO off;
+
+
+COPY vendor (vendor_id,vendor_type,normal_vendor_type,vendor_code,normal_vendor_code,vendor_name,normal_vendor_name,federal_tax_id,institution_id,default_currency,claim_interval,claim_count,cancel_interval,ship_via,create_date,create_opid,update_date,update_opid) FROM STDIN;
+3764	VE	VE	LQZ	LQZ	Library of Congress Cataloging Distribution Service	LIBRARY OF CONGRESS CATALOGING DISTRIBUTION SERVICE	\N	006039003	\N	0	0	0	\N	2004-06-04 11:33:09	CONVERSION	2021-05-21 11:14:52	rrivero
+\.
+
+COMMIT;
+
+BEGIN;
+
+SET client_encoding TO 'UTF8';
+SET synchronous_commit TO off;
+
+
+COPY vendor_account (account_id,vendor_id,account_number,account_name,default_po_type,deposit,default_discount,account_status,status_date) FROM STDIN;
+1	3764	552406-010	YRL Serials	5	\N	0	0	2004-07-15 13:47:24
+\.
+
+COMMIT;

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -1,0 +1,82 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+<form name="search_archive" id="search_archive" method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    <table>
+        {{ form.as_table }}
+    </table>
+    <br>
+    <button type="submit">Search</button>
+</form>
+<hr/>
+
+
+<div class="row">
+    <div class="column">
+        <h1>Vendor Information</h1>
+        <table class="data-display">
+            <tr>
+                <td>Vendor Code</td>
+                <td>{{ vendor.vendor_code }}</td>
+            </tr>
+            <tr>
+                <td>Vendor Name</td>
+                <td>{{ vendor.vendor_name }}</td>
+            </tr>
+            <tr>
+                <td>Vendor ID</td>
+                <td>{{ vendor.vendor_id }}</td>
+            </tr>
+            <tr>
+                <td>Vendor Type</td>
+                <td>{{ vendor.vendor_type }}</td>
+            </tr>
+            <tr>
+                <td>Institution ID</td>
+                <td>{{ vendor.institution_id }}</td>
+            </tr>
+            <tr>
+                <td>Federal Tax ID</td>
+                <td>{{ vendor.federal_tax_id }}</td>
+            </tr>
+            <tr>
+                <td>Vendor Note</td>
+                <td>{{ vendor.vendor_note }}</td>
+            </tr>
+            <tr>
+                <td>Default Currency</td>
+                <td>{{ vendor.default_currency }}</td>
+            </tr>
+            <tr>
+                <td>Claim Interval</td>
+                <td>{{ vendor.claim_interval }}</td>
+            </tr>
+            <tr>
+                <td>Claim Count</td>
+                <td>{{ vendor.claim_count }}</td>
+            </tr>
+            <tr>
+                <td>Cancel Interval</td>
+                <td>{{ vendor.cancel_interval }}</td>
+            </tr>
+            <tr>
+                <td>Creation Date</td>
+                <td>{{ vendor.create_date }}</td>
+            </tr>
+            <tr>
+                <td>Creation Operator ID</td>
+                <td>{{ vendor.create_operator_id }}</td>
+            </tr>
+            <tr>
+                <td>Modification Date</td>
+                <td>{{ vendor.modify_date }}</td>
+            </tr>
+            <tr>
+                <td>Modification Operator ID</td>
+                <td>{{ vendor.modify_operator_id }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -89,42 +89,31 @@
         {% for acct in vendor_accts %}
         <table class="data-display">
             <tr>
-                <td>Vendor ID</td>
-                <td>{{ acct.vendor_id }}</td>
-            </tr>
-            <tr>
-                <td>Account ID</td>
-                <td>{{ acct.account_id }}</td>
+                <td>Account Name</td>
+                <td>{{ acct.account_name }}</td>
             </tr>
             <tr>
                 <td>Account Number</td>
                 <td>{{ acct.account_number }}</td>
             </tr>
             <tr>
-                <td>Account Name</td>
-                <td>{{ acct.account_name }}</td>
+                <td>Vendor Account ID</td>
+                <td>{{ acct.vendor_account_id }}</td>
             </tr>
             <tr>
-                <td>Default PO Type</td>
-                <td>{{ acct.default_po_type }}</td>
+                <td>Vendor ID</td>
+                <td>{{ acct.vendor_id }}</td>
             </tr>
             <tr>
                 <td>Deposit</td>
                 <td>{{ acct.deposit }}</td>
             </tr>
             <tr>
-                <td>Default Discount</td>
-                <td>{{ acct.default_discount }}</td>
-            </tr>
-            <tr>
-                <td>Account Status</td>
-                <td>{{ acct.account_status }}</td>
-            </tr>
-            <tr>
-                <td>Status Date</td>
-                <td>{{ acct.status_date }}</td>
+                <td>Default PO Type</td>
+                <td>{{ acct.default_po_type }}</td>
             </tr>
         </table>
+        <br>
         {% endfor %}
         {% endif %}
     </div>

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -9,7 +9,7 @@
     <br>
     <button type="submit">Search</button>
 </form>
-<hr/>
+<hr>
 
 
 <div class="row">
@@ -113,7 +113,9 @@
                 <td>{{ acct.default_po_type }}</td>
             </tr>
         </table>
-        <br>
+        {% if not forloop.last %}
+        <hr>
+        {% endif %}
         {% endfor %}
         {% endif %}
     </div>

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -76,7 +76,57 @@
                 <td>Modification Operator ID</td>
                 <td>{{ vendor.modify_operator_id }}</td>
             </tr>
+            <tr>
+                <td>Number of Associated Accounts</td>
+                <td>{{ vendor_accts.count }}</td>
+            </tr>
         </table>
+    </div>
+
+    <div class="column">
+        {% if vendor_accts %}
+        <h1>Vendor Account Information</h1>
+        {% for acct in vendor_accts %}
+        <table class="data-display">
+            <tr>
+                <td>Vendor ID</td>
+                <td>{{ acct.vendor_id }}</td>
+            </tr>
+            <tr>
+                <td>Account ID</td>
+                <td>{{ acct.account_id }}</td>
+            </tr>
+            <tr>
+                <td>Account Number</td>
+                <td>{{ acct.account_number }}</td>
+            </tr>
+            <tr>
+                <td>Account Name</td>
+                <td>{{ acct.account_name }}</td>
+            </tr>
+            <tr>
+                <td>Default PO Type</td>
+                <td>{{ acct.default_po_type }}</td>
+            </tr>
+            <tr>
+                <td>Deposit</td>
+                <td>{{ acct.deposit }}</td>
+            </tr>
+            <tr>
+                <td>Default Discount</td>
+                <td>{{ acct.default_discount }}</td>
+            </tr>
+            <tr>
+                <td>Account Status</td>
+                <td>{{ acct.account_status }}</td>
+            </tr>
+            <tr>
+                <td>Status Date</td>
+                <td>{{ acct.status_date }}</td>
+            </tr>
+        </table>
+        {% endfor %}
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -21,6 +21,8 @@ def search(request: HttpRequest) -> None:
 
             marc_record = None
             item = None
+            vendor = None
+            vendor_acct_list = None
             if search_type == 'AUTH_ID':
                 marc_record = get_auth_record(search_term)
             elif search_type == 'BIB_ID':
@@ -29,6 +31,9 @@ def search(request: HttpRequest) -> None:
                 marc_record = get_mfhd_record(search_term)
             elif search_type == 'ITEM_BARCODE':
                 item = get_item(search_term)
+            elif search_type == 'VENDOR_CODE':
+                vendor = get_vendor(search_term)
+                #vendor_acct_list = get_vendor_accts(vendor.vendor_id)
 
             if marc_record:
                 context = {
@@ -45,6 +50,15 @@ def search(request: HttpRequest) -> None:
                 }
 
                 return render(request, 'voyager_archive/item_display.html', context)
+            
+            elif vendor:
+                context = {
+                    'form': form,
+                    'vendor': vendor#,
+                    #'vendor_acct_list': vendor_acct_list
+                }
+
+                return render(request, 'voyager_archive/vendor_display.html', context)
     else:
         form = VoyArchiveForm()
         return render(request, 'voyager_archive/search.html', {'form': form})

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -33,7 +33,7 @@ def search(request: HttpRequest) -> None:
                 item = get_item(search_term)
             elif search_type == 'VENDOR_CODE':
                 vendor = get_vendor(search_term)
-                #vendor_acct_list = get_vendor_accts(vendor.vendor_id)
+                vendor_accts = get_vendor_accts(vendor.vendor_id)
 
             if marc_record:
                 context = {
@@ -54,8 +54,8 @@ def search(request: HttpRequest) -> None:
             elif vendor:
                 context = {
                     'form': form,
-                    'vendor': vendor#,
-                    #'vendor_acct_list': vendor_acct_list
+                    'vendor': vendor,
+                    'vendor_accts': vendor_accts
                 }
 
                 return render(request, 'voyager_archive/vendor_display.html', context)

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,5 +1,6 @@
 from django.shortcuts import get_object_or_404, get_list_or_404
 from pymarc import Record
+from django.db.models import QuerySet
 from .models import AuthRecord, BibRecord, MfhdRecord, ItemView, VendorView, VendorAccountView
 
 
@@ -35,7 +36,7 @@ def get_vendor(vendor_code: str) -> VendorView:
 
     return vendor
 
-def get_vendor_accts(vendor_id: int):
+def get_vendor_accts(vendor_id: int) -> QuerySet:
     vendor_accts = VendorAccountView.objects.filter(vendor_id=vendor_id)
 
     return vendor_accts

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -34,3 +34,8 @@ def get_vendor(vendor_code: str) -> VendorView:
     vendor = get_object_or_404(VendorView, vendor_code=vendor_code)
 
     return vendor
+
+def get_vendor_accts(vendor_id: int):
+    vendor_accts = VendorAccountView.objects.filter(vendor_id=vendor_id)
+
+    return vendor_accts

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,6 +1,6 @@
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, get_list_or_404
 from pymarc import Record
-from .models import AuthRecord, BibRecord, MfhdRecord, ItemView
+from .models import AuthRecord, BibRecord, MfhdRecord, ItemView, VendorView, VendorAccountView
 
 
 def get_auth_record(auth_id: int) -> list:
@@ -29,3 +29,8 @@ def get_item(item_barcode: str) -> ItemView:
     item = get_object_or_404(ItemView, item_barcode=item_barcode)
 
     return item
+
+def get_vendor(vendor_code: str) -> VendorView:
+    vendor = get_object_or_404(VendorView, vendor_code=vendor_code)
+
+    return vendor

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,4 +1,4 @@
-from django.shortcuts import get_object_or_404, get_list_or_404
+from django.shortcuts import get_object_or_404
 from pymarc import Record
 from django.db.models import QuerySet
 from .models import AuthRecord, BibRecord, MfhdRecord, ItemView, VendorView, VendorAccountView


### PR DESCRIPTION
Related to [SYS-1001](https://jira.library.ucla.edu/browse/SYS-1001)

Allows users to search by Vendor Code and displays associated VendorView and VendorAccountView data. Account data (if exists) is shown in a second column of tables. An additional row ("Number of Associated Accounts") at the bottom of the Vendor table gives the number of expected Account tables - not sure if this is necessary. 

Also adds test vendor account data provided by Andy to sql_support/sample_data.sql. Available vendor codes are now "LQZ" and "YAGI". 

![image](https://user-images.githubusercontent.com/7283991/194414684-fea0cf00-9672-466f-9aec-5b376c14dcbd.png)
