### PR TITLE
SYS-983: Display purchase orders

### DIFF
--- a/sql_support/create_psql_tables.sql
+++ b/sql_support/create_psql_tables.sql
@@ -1259,3 +1259,10 @@ CREATE TABLE mfhd_record (
 ) ;
 
 
+/*
+* Table for minimal bib data needed for po / invoice lines
+*/
+CREATE TABLE bib_title (
+	bib_id numeric(38) primary key,
+	title text
+) ;

--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -203,7 +203,8 @@ select
 ,	va.account_number as vendor_acccount_number
 ,	po.po_number
 ,	po.currency_code
-,	po.conversion_rate
+-- conversion_rate needs to be scaled by 100,000
+,	po.conversion_rate / 100000 as conversion_rate
 ,	pot.po_type_desc as po_type
 ,	pos.po_status_desc as po_status
 ,	po.po_status_date as status_date
@@ -247,6 +248,7 @@ select
 ,	li.bib_id
 ,	lics.copy_id
 ,	lics.mfhd_id
+,	bt.title
 ,	l.location_code
 ,	po.po_number
 ,	lit.line_item_type_desc as line_item_type
@@ -286,6 +288,7 @@ inner join line_item_funds lif on lics.copy_id = lif.copy_id
 inner join fund f on lif.ledger_id = f.ledger_id and lif.fund_id = f.fund_id
 inner join ledger lg on f.ledger_id = lg.ledger_id
 inner join location l on lics.location_id = l.location_id
+inner join bib_title bt on li.bib_id = bt.bib_id
 left outer join line_item_notes lin on li.line_item_id = lin.line_item_id
 ;
 

--- a/sql_support/sample_data.sql
+++ b/sql_support/sample_data.sql
@@ -127,6 +127,8 @@ SET synchronous_commit TO off;
 
 COPY ledger (ledger_id,fiscal_year_id,acq_policy_id,ledger_name,normal_ledger_name,overcommit,overcommit_warn,overcommit_percent,commit_freeze,undercommit_percent,overexpend,overexpend_warn,overexpend_percent,expend_freeze,underexpend_percent,create_date,create_opid,update_date,update_opid,rule_id,new_ledger_name,normal_new_ledger_name,new_ledger_id) FROM STDIN;
 326	17	1	EAST ASIAN 20-21	EAST ASIAN 20 21	N	0	0	\N	0	N	0	0	\N	0	2020-07-01 09:12:50	<R>	2020-07-01 09:12:50	\N	32	EAST ASIAN 21-22	EAST ASIAN 21 22	344
+336	17	1	MUSIC 20-21	MUSIC 20 21	N	0	0	\N	0	N	0	0	\N	0	2020-07-01 09:12:53	<R>	2020-07-01 09:12:53	\N	32	MUSIC 21-22	MUSIC 21 22	354
+355	18	1	IS 21-22	IS 21 22	N	0	0	\N	0	N	0	0	\N	0	2021-06-05 06:00:08	<R>	2021-06-05 06:00:08	\N	0	\N	\N	0
 \.
 
 COMMIT;
@@ -143,6 +145,8 @@ COPY fund (fund_id,ledger_id,parent_fund,fund_name,normal_fund_name,fund_code,no
 3777	290	3771	Japanese Mono Prt	JAPANESE MONO PRT	L3MPEAJA-2	L3MPEAJA 2	2	1	\N	\N	4 603800 LM 19900 05 9200 JAPAN	N	0	0	0	0	0	0	7801575	N	0	0	\N	0	N	0	0	\N	0	2018-07-06 11:43:45	<R>	2018-07-06 11:43:45	\N
 3777	326	3771	Japanese Mono Prt	JAPANESE MONO PRT	L3MPEAJA-2	L3MPEAJA 2	2	1	\N	\N	4 603800 LM 19900 05 9200 JAPAN	N	0	0	0	0	0	0	9134942	N	0	0	\N	0	N	0	0	\N	0	2020-07-01 09:12:50	<R>	2020-07-01 09:12:50	\N
 3777	308	3771	Japanese Mono Prt	JAPANESE MONO PRT	L3MPEAJA-2	L3MPEAJA 2	2	1	\N	\N	4 603800 LM 19900 05 9200 JAPAN	N	0	0	0	0	0	0	8458688	N	0	0	\N	0	N	0	0	\N	0	2019-07-01 09:11:24	<R>	2019-07-01 09:11:24	\N
+6758	355	6757	Western European Mono	WESTERN EUROPEAN MONO	1IS117	1IS117	1	1	\N	\N	4 606800 LM 18082 05 9200	N	2662600	0	0	0	450986	0	0	Y	115	115	\N	0	Y	115	115	\N	0	2021-06-05 06:00:08	<R>	2021-06-08 16:19:23	asallen
+4717	336	4703	Music Mono Scores	MUSIC MONO SCORES	L3MSMUMU-2	L3MSMUMU 2	2	1	\N	\N	4 603520 LM 19900 05 9200	N	0	0	0	0	0	0	1678948	N	0	0	\N	0	N	0	0	\N	0	2020-07-01 09:12:53	<R>	2020-07-01 09:12:53	\N
 \.
 
 COMMIT;
@@ -155,6 +159,7 @@ SET synchronous_commit TO off;
 
 COPY vendor (vendor_id,vendor_type,normal_vendor_type,vendor_code,normal_vendor_code,vendor_name,normal_vendor_name,federal_tax_id,institution_id,default_currency,claim_interval,claim_count,cancel_interval,ship_via,create_date,create_opid,update_date,update_opid) FROM STDIN;
 6718	VE	VE	YAGI	YAGI	YAGI Book Store Ltd.	YAGI BOOK STORE LTD	\N	188657001	\N	0	0	0	\N	2004-12-20 14:50:31	rsiao	2017-08-28 12:02:30	ncasner
+2264	VE	VE	HAR	HAR	Harrassowitz	HARRASSOWITZ	\N	006800004	\N	0	0	0	\N	2004-06-04 11:33:09	CONVERSION	2017-12-15 09:43:20	ncasner
 \.
 
 COMMIT;
@@ -317,6 +322,11 @@ SET synchronous_commit TO off;
 
 COPY location (location_id,location_code,location_name,location_display_name,location_spine_label,location_opac,suppress_in_opac,library_id,mfhd_count) FROM STDIN;
 146	ea**	EA Stacks**	East Asian Library Stacks Oversize**	E. Asian;Lib.	Y	N	1	18
+147	eaacq	*East Asian Acquisitions	East Asian Library Acquisitions Department	\N	Y	N	1	1208
+292	muacq	*Music Acq Dept	Music Library Acquisitions Department	\N	Y	N	1	107
+575	musmon	+Music Monographs	\N	\N	\N	Y	1	0
+288	mu	Music Stacks	Music Library	Music Lib.	Y	N	1	83383
+460	yr	YRL Stacks	YRL	\N	Y	N	1	1516861
 \.
 
 COMMIT;
@@ -442,6 +452,52 @@ SET synchronous_commit TO off;
 
 COPY vendor_account (account_id,vendor_id,account_number,account_name,default_po_type,deposit,default_discount,account_status,status_date) FROM STDIN;
 1	3764	552406-010	YRL Serials	5	\N	0	0	2004-07-15 13:47:24
+\.
+
+COMMIT;
+
+BEGIN;
+
+SET client_encoding TO 'UTF8';
+SET synchronous_commit TO off;
+
+
+COPY line_item_type (line_item_type,line_item_type_desc) FROM STDIN;
+0	Single-part
+1	Subscription
+2	Membership
+3	Standing Order
+4	Blanket Order
+5	Multi-part
+6	Approval
+\.
+
+COMMIT;
+
+BEGIN;
+
+SET client_encoding TO 'UTF8';
+SET synchronous_commit TO off;
+
+
+COPY line_item_funds (copy_id,split_fund_seq,ledger_id,fund_id,percentage,prepay_percentage,amount,prepay,allocation_method) FROM STDIN;
+1159093	1	326	3777	100000000	100000000	0	0	P
+128592	1	355	6758	100000000	0	0	0	P
+1185415	1	336	4717	100000000	100000000	4400	0	P
+\.
+
+COMMIT;
+
+BEGIN;
+
+SET client_encoding TO 'UTF8';
+SET synchronous_commit TO off;
+
+
+COPY bib_title (bib_id,title) FROM STDIN;
+9411434	Edo hanpon shūyō /
+4507	The complete works of Voltaire /
+9467582	Brandnä va /
 \.
 
 COMMIT;

--- a/voyager_archive/models.py
+++ b/voyager_archive/models.py
@@ -2,31 +2,41 @@ from django.db import models
 
 
 class AccountLocation(models.Model):
-    account_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    account_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    account_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    account_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'account_location'
+        db_table = "account_location"
 
 
 class AccountNote(models.Model):
-    account_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    account_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     note = models.CharField(max_length=1900, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'account_note'
+        db_table = "account_note"
 
 
 class AddressType(models.Model):
-    address_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    address_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     address_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'address_type'
+        db_table = "address_type"
 
 
 class AdjustReason(models.Model):
@@ -34,11 +44,13 @@ class AdjustReason(models.Model):
     reason_text = models.CharField(max_length=50, blank=True, null=True)
     charge_or_credit = models.CharField(max_length=1, blank=True, null=True)
     reason_edi_code = models.CharField(max_length=250, blank=True, null=True)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'adjust_reason'
+        db_table = "adjust_reason"
 
 
 class AuthRecord(models.Model):
@@ -47,36 +59,45 @@ class AuthRecord(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'auth_record'
+        db_table = "auth_record"
 
 
 class BibMaster(models.Model):
     bib_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    library_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    library_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     suppress_in_opac = models.CharField(max_length=1, blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     update_date = models.DateTimeField(blank=True, null=True)
     export_ok = models.CharField(max_length=1, blank=True, null=True)
     export_ok_date = models.DateTimeField(blank=True, null=True)
     export_ok_opid = models.CharField(max_length=10, blank=True, null=True)
-    export_ok_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    export_ok_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     export_date = models.DateTimeField(blank=True, null=True)
     exists_in_dps = models.CharField(max_length=1)
     exists_in_dps_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'bib_master'
+        db_table = "bib_master"
 
 
 class BibMfhd(models.Model):
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'bib_mfhd'
-        unique_together = (('bib_id', 'mfhd_id'), ('mfhd_id', 'bib_id'),)
+        db_table = "bib_mfhd"
+        unique_together = (
+            ("bib_id", "mfhd_id"),
+            ("mfhd_id", "bib_id"),
+        )
 
 
 class BibRecord(models.Model):
@@ -85,67 +106,113 @@ class BibRecord(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'bib_record'
+        db_table = "bib_record"
 
 
 class CallSlip(models.Model):
-    call_slip_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    print_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    call_slip_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    print_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     date_requested = models.DateTimeField(blank=True, null=True)
     date_processed = models.DateTimeField(blank=True, null=True)
-    location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     status_date = models.DateTimeField(blank=True, null=True)
     status_opid = models.CharField(max_length=10, blank=True, null=True)
-    no_fill_reason = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    no_fill_reason = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_year = models.CharField(max_length=20, blank=True, null=True)
     item_enum = models.CharField(max_length=80, blank=True, null=True)
     item_chron = models.CharField(max_length=80, blank=True, null=True)
     note = models.CharField(max_length=100, blank=True, null=True)
-    pickup_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    pickup_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    not_needed_after = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    pickup_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    pickup_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    not_needed_after = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     reply_note = models.CharField(max_length=100, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'call_slip'
+        db_table = "call_slip"
 
 
 class CallSlipArchive(models.Model):
     archive_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    print_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    print_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     date_requested = models.DateTimeField(blank=True, null=True)
     date_processed = models.DateTimeField(blank=True, null=True)
-    location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     status_date = models.DateTimeField(blank=True, null=True)
     status_opid = models.CharField(max_length=10, blank=True, null=True)
-    no_fill_reason = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    no_fill_reason = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_year = models.CharField(max_length=20, blank=True, null=True)
     item_enum = models.CharField(max_length=80, blank=True, null=True)
     item_chron = models.CharField(max_length=80, blank=True, null=True)
     note = models.CharField(max_length=100, blank=True, null=True)
-    pickup_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    pickup_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    not_needed_after = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    pickup_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    pickup_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    not_needed_after = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     reply_note = models.CharField(max_length=100, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'call_slip_archive'
+        db_table = "call_slip_archive"
 
 
 class CallSlipStatusType(models.Model):
@@ -154,98 +221,160 @@ class CallSlipStatusType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'call_slip_status_type'
+        db_table = "call_slip_status_type"
 
 
 class CircTransArchive(models.Model):
-    circ_transaction_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    circ_policy_matrix_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    circ_transaction_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    circ_policy_matrix_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     charge_date = models.DateTimeField(blank=True, null=True)
-    charge_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    charge_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     charge_type = models.CharField(max_length=1, blank=True, null=True)
     charge_oper_id = models.CharField(max_length=10, blank=True, null=True)
     due_date = models.DateTimeField(blank=True, null=True)
     discharge_date = models.DateTimeField(blank=True, null=True)
-    discharge_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    discharge_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     discharge_type = models.CharField(max_length=1, blank=True, null=True)
     discharge_oper_id = models.CharField(max_length=10, blank=True, null=True)
-    renewal_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    renewal_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     recall_date = models.DateTimeField(blank=True, null=True)
     recall_due_date = models.DateTimeField(blank=True, null=True)
-    recall_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    recall_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     recall_notice_date = models.DateTimeField(blank=True, null=True)
-    overdue_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overdue_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overdue_notice_date = models.DateTimeField(blank=True, null=True)
-    over_recall_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    over_recall_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     over_recall_notice_date = models.DateTimeField(blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id_proxy = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id_proxy = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     courtesy_notice_date = models.DateTimeField(blank=True, null=True)
     db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'circ_trans_archive'
+        db_table = "circ_trans_archive"
 
 
 class CircTransExceptType(models.Model):
-    exception_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    exception_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     exception_desc = models.CharField(max_length=50, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'circ_trans_except_type'
+        db_table = "circ_trans_except_type"
 
 
 class CircTransException(models.Model):
-    circ_trans_except_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    circ_trans_except_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     trans_except_date = models.DateTimeField(blank=True, null=True)
-    trans_except_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    trans_except_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    trans_except_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    trans_except_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     trans_except_oper_id = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'circ_trans_exception'
+        db_table = "circ_trans_exception"
 
 
 class CircTransactions(models.Model):
-    circ_transaction_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    circ_policy_matrix_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id_proxy = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    circ_transaction_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    circ_policy_matrix_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id_proxy = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     charge_date = models.DateTimeField(blank=True, null=True)
-    charge_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    charge_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     charge_type = models.CharField(max_length=1, blank=True, null=True)
     charge_oper_id = models.CharField(max_length=10, blank=True, null=True)
     charge_due_date = models.DateTimeField(blank=True, null=True)
     discharge_date = models.DateTimeField(blank=True, null=True)
-    discharge_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    discharge_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     discharge_type = models.CharField(max_length=1, blank=True, null=True)
     discharge_oper_id = models.CharField(max_length=10, blank=True, null=True)
-    renewal_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    renewal_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     recall_date = models.DateTimeField(blank=True, null=True)
     recall_due_date = models.DateTimeField(blank=True, null=True)
     current_due_date = models.DateTimeField(blank=True, null=True)
-    recall_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    recall_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     recall_notice_date = models.DateTimeField(blank=True, null=True)
-    overdue_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overdue_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overdue_notice_date = models.DateTimeField(blank=True, null=True)
-    over_recall_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    over_recall_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     over_recall_notice_date = models.DateTimeField(blank=True, null=True)
     courtesy_notice_date = models.DateTimeField(blank=True, null=True)
     db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'circ_transactions'
+        db_table = "circ_transactions"
 
 
 class ClaimTypes(models.Model):
@@ -255,7 +384,7 @@ class ClaimTypes(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'claim_types'
+        db_table = "claim_types"
 
 
 class CurrencyConversion(models.Model):
@@ -268,27 +397,43 @@ class CurrencyConversion(models.Model):
     normal_currency_code = models.CharField(max_length=3, blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    conversion_rate = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    conversion_rate = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     rate_create_date_time = models.DateTimeField(blank=True, null=True)
     rate_create_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    decimals = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    decimals = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     decimal_delimiter = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'currency_conversion'
+        db_table = "currency_conversion"
 
 
 class FineFee(models.Model):
     fine_fee_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     operator_id = models.CharField(max_length=10, blank=True, null=True)
-    fine_fee_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fine_fee_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fine_fee_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fine_fee_balance = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fine_fee_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fine_fee_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fine_fee_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fine_fee_balance = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     fine_fee_note = models.CharField(max_length=1000, blank=True, null=True)
     orig_charge_date = models.DateTimeField(blank=True, null=True)
     due_date = models.DateTimeField(blank=True, null=True)
@@ -297,11 +442,13 @@ class FineFee(models.Model):
     discharge_date = models.DateTimeField(blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     modify_oper_id = models.CharField(max_length=10, blank=True, null=True)
-    modify_loc_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    modify_loc_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'fine_fee'
+        db_table = "fine_fee"
 
 
 class FineFeeTransMethod(models.Model):
@@ -310,88 +457,142 @@ class FineFeeTransMethod(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'fine_fee_trans_method'
+        db_table = "fine_fee_trans_method"
 
 
 class FineFeeTransType(models.Model):
-    transaction_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    transaction_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     transaction_desc = models.CharField(max_length=25, blank=True, null=True)
     type_fine = models.CharField(max_length=1, blank=True, null=True)
     type_demerit = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fine_fee_trans_type'
+        db_table = "fine_fee_trans_type"
 
 
 class FineFeeTransactions(models.Model):
-    fine_fee_trans_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    fine_fee_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fine_fee_trans_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    fine_fee_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     trans_date = models.DateTimeField(blank=True, null=True)
-    trans_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    trans_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    trans_method = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    trans_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    trans_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    trans_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    trans_method = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    trans_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     operator_id = models.CharField(max_length=10, blank=True, null=True)
     trans_note = models.CharField(max_length=1000, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fine_fee_transactions'
+        db_table = "fine_fee_transactions"
 
 
 class FineFeeType(models.Model):
-    fine_fee_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    fine_fee_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     fine_fee_desc = models.CharField(max_length=25, blank=True, null=True)
     fine_fee_code = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fine_fee_type'
+        db_table = "fine_fee_type"
 
 
 class FiscalPeriod(models.Model):
-    fiscal_period_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    fiscal_period_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     fiscal_period_name = models.CharField(max_length=25, blank=True, null=True)
     start_date = models.DateTimeField(blank=True, null=True)
     end_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fiscal_period'
+        db_table = "fiscal_period"
 
 
 class Fund(models.Model):
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    parent_fund = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    parent_fund = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     fund_name = models.CharField(max_length=25, blank=True, null=True)
     normal_fund_name = models.CharField(max_length=25, blank=True, null=True)
     fund_code = models.CharField(max_length=10, blank=True, null=True)
     normal_fund_code = models.CharField(max_length=10, blank=True, null=True)
-    category = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    category = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     begin_date = models.DateTimeField(blank=True, null=True)
     end_date = models.DateTimeField(blank=True, null=True)
     institution_fund_id = models.CharField(max_length=50, blank=True, null=True)
     expend_only = models.CharField(max_length=1, blank=True, null=True)
-    original_allocation = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    allocation_increase = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    allocation_decrease = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commit_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commitments = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expend_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expenditures = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    original_allocation = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    allocation_increase = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    allocation_decrease = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commit_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commitments = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expend_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expenditures = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overcommit = models.CharField(max_length=1, blank=True, null=True)
-    overcommit_warn = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overcommit_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overcommit_warn = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overcommit_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     commit_freeze = models.DateTimeField(blank=True, null=True)
-    undercommit_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    undercommit_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overexpend = models.CharField(max_length=1, blank=True, null=True)
-    overexpend_warn = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overexpend_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overexpend_warn = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overexpend_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expend_freeze = models.DateTimeField(blank=True, null=True)
-    underexpend_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    underexpend_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
     update_date = models.DateTimeField(blank=True, null=True)
@@ -399,250 +600,410 @@ class Fund(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'fund'
-        unique_together = (('ledger_id', 'fund_id'),)
+        db_table = "fund"
+        unique_together = (("ledger_id", "fund_id"),)
 
 
 class FundNote(models.Model):
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     fund_note = models.CharField(max_length=1900, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fund_note'
-        unique_together = (('fund_id', 'ledger_id'),)
+        db_table = "fund_note"
+        unique_together = (("fund_id", "ledger_id"),)
 
 
 class FundPayment(models.Model):
     payment_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    split_fund_seq = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    percentage = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    split_fund_seq = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    percentage = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fund_payment'
+        db_table = "fund_payment"
 
 
 class FundTransaction(models.Model):
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     audit_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    trans_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    trans_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     trans_date = models.DateTimeField(blank=True, null=True)
     operator_id = models.CharField(max_length=10, blank=True, null=True)
     reference_no = models.CharField(max_length=25, blank=True, null=True)
-    statistical_fund = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    statistical_fund = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     note = models.CharField(max_length=1900, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'fund_transaction'
+        db_table = "fund_transaction"
 
 
 class FundType(models.Model):
-    fund_type_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    fund_type_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     fund_type_name = models.CharField(max_length=25, blank=True, null=True)
-    commit_warning = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expend_warning = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overcommit_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overexpend_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    undercommit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    underexpend = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    commit_warning = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expend_warning = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overcommit_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overexpend_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    undercommit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    underexpend = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'fund_type'
+        db_table = "fund_type"
 
 
 class HoldRecall(models.Model):
-    hold_recall_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    hold_recall_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     hold_recall_type = models.CharField(max_length=1, blank=True, null=True)
-    pickup_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    pickup_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expire_date = models.DateTimeField(blank=True, null=True)
-    available_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    available_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     available_notice_date = models.DateTimeField(blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
-    create_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     request_level = models.CharField(max_length=1, blank=True, null=True)
-    request_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    request_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    request_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    request_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_comment = models.CharField(max_length=100, blank=True, null=True)
     patron_group_id = models.BigIntegerField(blank=True, null=True)
-    call_slip_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    holding_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    call_slip_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    holding_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     modify_opid = models.CharField(max_length=10, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
-    modify_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    modify_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'hold_recall'
+        db_table = "hold_recall"
 
 
 class HoldRecallArchive(models.Model):
-    hold_recall_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    hold_recall_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     hold_recall_type = models.CharField(max_length=1, blank=True, null=True)
-    pickup_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    pickup_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expire_date = models.DateTimeField(blank=True, null=True)
-    available_notice_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    available_notice_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     available_notice_date = models.DateTimeField(blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
-    create_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     request_level = models.CharField(max_length=1, blank=True, null=True)
-    request_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    request_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    request_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    request_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_comment = models.CharField(max_length=100, blank=True, null=True)
     patron_id = models.BigIntegerField(blank=True, null=True)
     patron_group_id = models.BigIntegerField(blank=True, null=True)
-    call_slip_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    holding_db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    call_slip_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    holding_db_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     modify_opid = models.CharField(max_length=10, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
-    modify_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    modify_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'hold_recall_archive'
+        db_table = "hold_recall_archive"
 
 
 class HoldRecallItemArchive(models.Model):
-    hold_recall_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    hold_recall_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     hold_recall_type = models.CharField(max_length=1, blank=True, null=True)
-    hold_recall_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    hold_recall_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     hold_recall_status_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'hold_recall_item_archive'
+        db_table = "hold_recall_item_archive"
 
 
 class HoldRecallItems(models.Model):
-    hold_recall_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    queue_position = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    hold_recall_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    queue_position = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     hold_recall_type = models.CharField(max_length=1, blank=True, null=True)
-    hold_recall_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    hold_recall_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     hold_recall_status_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'hold_recall_items'
+        db_table = "hold_recall_items"
 
 
 class HoldRecallStatus(models.Model):
-    hr_status_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    hr_status_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     hr_status_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'hold_recall_status'
+        db_table = "hold_recall_status"
 
 
 class InvLineItemNotes(models.Model):
-    inv_line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    invoice_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    inv_line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    invoice_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     note = models.CharField(max_length=1900, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'inv_line_item_notes'
+        db_table = "inv_line_item_notes"
 
 
 class Invoice(models.Model):
     invoice_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    account_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    account_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     invoice_number = models.CharField(max_length=25, blank=True, null=True)
     normal_invoice_number = models.CharField(max_length=25, blank=True, null=True)
-    invoice_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    invoice_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     invoice_status_date = models.DateTimeField(blank=True, null=True)
     invoice_date = models.DateTimeField(blank=True, null=True)
     voucher_number = models.CharField(max_length=25, blank=True, null=True)
     currency_code = models.CharField(max_length=3, blank=True, null=True)
-    conversion_rate = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    invoice_total = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    bill_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    invoice_quantity = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_subtotal = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    adjustments_subtotal = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    conversion_rate = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    invoice_total = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    bill_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    invoice_quantity = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_subtotal = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    adjustments_subtotal = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     total = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     invoice_create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
-    create_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     invoice_update_date = models.DateTimeField(blank=True, null=True)
     update_opid = models.CharField(max_length=10, blank=True, null=True)
-    update_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    edi_ref = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    update_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    edi_ref = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expend_date = models.DateTimeField(blank=True, null=True)
     check_number = models.CharField(max_length=40, blank=True, null=True)
     normal_check_number = models.CharField(max_length=40, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'invoice'
+        db_table = "invoice"
 
 
 class InvoiceFunds(models.Model):
-    invoice_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commit_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commitments = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expend_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expenditures = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    invoice_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commit_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commitments = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expend_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expenditures = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'invoice_funds'
-        unique_together = (('invoice_id', 'ledger_id', 'fund_id'),)
+        db_table = "invoice_funds"
+        unique_together = (("invoice_id", "ledger_id", "fund_id"),)
 
 
 class InvoiceLineItem(models.Model):
-    inv_line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    invoice_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    unit_price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    quantity = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    prepay_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    inv_line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    invoice_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    unit_price = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_price = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    quantity = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    prepay_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     piece_identifier = models.CharField(max_length=500, blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
     update_date = models.DateTimeField(blank=True, null=True)
     update_opid = models.CharField(max_length=10, blank=True, null=True)
-    edi_ref = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    edi_ref = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'invoice_line_item'
+        db_table = "invoice_line_item"
 
 
 class InvoiceLineItemFunds(models.Model):
-    copy_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    inv_line_item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    split_fund_seq = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    percentage = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    copy_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    inv_line_item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    split_fund_seq = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    percentage = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     allocation_method = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'invoice_line_item_funds'
-        unique_together = (('copy_id', 'split_fund_seq', 'inv_line_item_id'),)
+        db_table = "invoice_line_item_funds"
+        unique_together = (("copy_id", "split_fund_seq", "inv_line_item_id"),)
 
 
 class InvoiceNote(models.Model):
@@ -651,81 +1012,121 @@ class InvoiceNote(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'invoice_note'
+        db_table = "invoice_note"
 
 
 class InvoiceStatus(models.Model):
-    invoice_status = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    invoice_status = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     invoice_status_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'invoice_status'
+        db_table = "invoice_status"
 
 
 class Item(models.Model):
     item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    perm_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    temp_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_type_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    temp_item_type_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    copy_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    perm_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    temp_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_type_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    temp_item_type_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    copy_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     on_reserve = models.CharField(max_length=1, blank=True, null=True)
-    reserve_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    reserve_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     pieces = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     spine_label = models.CharField(max_length=25, blank=True, null=True)
-    historical_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_browses = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    recalls_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    holds_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    historical_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_browses = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    recalls_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    holds_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    create_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    modify_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_sequence_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_bookings = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    media_type_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    modify_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_sequence_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_bookings = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    media_type_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     short_loan_charges = models.BigIntegerField(blank=True, null=True)
     magnetic_media = models.CharField(max_length=1, blank=True, null=True)
     sensitize = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item'
+        db_table = "item"
 
 
 class ItemBarcode(models.Model):
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_barcode = models.CharField(max_length=30, blank=True, null=True)
-    barcode_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    barcode_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     barcode_status_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_barcode'
+        db_table = "item_barcode"
 
 
 class ItemBarcodeStatus(models.Model):
-    barcode_status_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    barcode_status_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     barcode_status_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_barcode_status'
+        db_table = "item_barcode_status"
 
 
 class ItemNote(models.Model):
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_note = models.CharField(max_length=1000, blank=True, null=True)
     item_note_type = models.BigIntegerField()
     last_modified = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_note'
+        db_table = "item_note"
 
 
 class ItemNoteType(models.Model):
@@ -734,88 +1135,122 @@ class ItemNoteType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'item_note_type'
+        db_table = "item_note_type"
 
 
 class ItemStatCode(models.Model):
-    item_stat_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    item_stat_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     item_stat_code = models.CharField(max_length=3, blank=True, null=True)
     item_stat_code_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_stat_code'
+        db_table = "item_stat_code"
 
 
 class ItemStats(models.Model):
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_stat_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_stat_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     date_applied = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_stats'
+        db_table = "item_stats"
 
 
 class ItemStatus(models.Model):
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_status_date = models.DateTimeField(blank=True, null=True)
     item_status_operator = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_status'
+        db_table = "item_status"
 
 
 class ItemStatusType(models.Model):
-    item_status_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    item_status_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     item_status_desc = models.CharField(max_length=25)
 
     class Meta:
         managed = False
-        db_table = 'item_status_type'
+        db_table = "item_status_type"
 
 
 class ItemType(models.Model):
-    item_type_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    item_type_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     item_type_code = models.CharField(max_length=10, blank=True, null=True)
     item_type_name = models.CharField(max_length=25, blank=True, null=True)
     item_type_display = models.CharField(max_length=40, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'item_type'
+        db_table = "item_type"
 
 
 class Ledger(models.Model):
     ledger_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    fiscal_year_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    acq_policy_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    fiscal_year_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    acq_policy_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     ledger_name = models.CharField(max_length=40, blank=True, null=True)
     normal_ledger_name = models.CharField(max_length=40, blank=True, null=True)
     overcommit = models.CharField(max_length=1, blank=True, null=True)
-    overcommit_warn = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overcommit_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overcommit_warn = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overcommit_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     commit_freeze = models.DateTimeField(blank=True, null=True)
-    undercommit_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    undercommit_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overexpend = models.CharField(max_length=1, blank=True, null=True)
-    overexpend_warn = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    overexpend_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overexpend_warn = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    overexpend_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expend_freeze = models.DateTimeField(blank=True, null=True)
-    underexpend_percent = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    underexpend_percent = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
     update_date = models.DateTimeField(blank=True, null=True)
     update_opid = models.CharField(max_length=10, blank=True, null=True)
-    rule_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    rule_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     new_ledger_name = models.CharField(max_length=40, blank=True, null=True)
     normal_new_ledger_name = models.CharField(max_length=40, blank=True, null=True)
-    new_ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    new_ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'ledger'
+        db_table = "ledger"
 
 
 class LedgerNote(models.Model):
@@ -824,24 +1259,42 @@ class LedgerNote(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'ledger_note'
+        db_table = "ledger_note"
 
 
 class LineItem(models.Model):
-    line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     po_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     piece_identifier = models.CharField(max_length=50, blank=True, null=True)
-    unit_price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    unit_price = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_price = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     print_std_num = models.CharField(max_length=2, blank=True, null=True)
-    quantity = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    prepay_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    quantity = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    prepay_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     rush = models.CharField(max_length=1, blank=True, null=True)
-    claim_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    cancel_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    claim_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    cancel_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     donor = models.CharField(max_length=50, blank=True, null=True)
     requestor = models.CharField(max_length=50, blank=True, null=True)
     vendor_title_num = models.CharField(max_length=25, blank=True, null=True)
@@ -851,88 +1304,132 @@ class LineItem(models.Model):
     create_opid = models.CharField(max_length=10, blank=True, null=True)
     update_date = models.DateTimeField(blank=True, null=True)
     update_opid = models.CharField(max_length=10, blank=True, null=True)
-    edi_ref = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    edi_ref = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     standard_num = models.CharField(max_length=50, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item'
+        db_table = "line_item"
 
 
 class LineItemCopy(models.Model):
-    line_item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ship_to_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    copy_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    use_ledger = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    use_fund = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ship_to_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    copy_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    use_ledger = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    use_fund = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'line_item_copy'
-        unique_together = (('line_item_id', 'location_id'),)
+        db_table = "line_item_copy"
+        unique_together = (("line_item_id", "location_id"),)
 
 
 class LineItemCopyStatus(models.Model):
-    line_item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     copy_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    invoice_item_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    invoice_item_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     status_date = models.DateTimeField(blank=True, null=True)
     receive_operator = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item_copy_status'
+        db_table = "line_item_copy_status"
 
 
 class LineItemFunds(models.Model):
-    copy_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    split_fund_seq = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    percentage = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    prepay_percentage = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    copy_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    split_fund_seq = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    percentage = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    prepay_percentage = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     prepay = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     allocation_method = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item_funds'
-        unique_together = (('copy_id', 'split_fund_seq'),)
+        db_table = "line_item_funds"
+        unique_together = (("copy_id", "split_fund_seq"),)
 
 
 class LineItemNotes(models.Model):
-    line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     po_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     print_note = models.CharField(max_length=60, blank=True, null=True)
     note = models.CharField(max_length=1900, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item_notes'
+        db_table = "line_item_notes"
 
 
 class LineItemStatus(models.Model):
-    line_item_status = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    line_item_status = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     line_item_status_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item_status'
+        db_table = "line_item_status"
 
 
 class LineItemType(models.Model):
-    line_item_type = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    line_item_type = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     line_item_type_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'line_item_type'
+        db_table = "line_item_type"
 
 
 class Location(models.Model):
@@ -943,17 +1440,25 @@ class Location(models.Model):
     location_spine_label = models.CharField(max_length=25, blank=True, null=True)
     location_opac = models.CharField(max_length=1, blank=True, null=True)
     suppress_in_opac = models.CharField(max_length=1, blank=True, null=True)
-    library_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    mfhd_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    library_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    mfhd_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'location'
+        db_table = "location"
 
 
 class MfhdItem(models.Model):
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     item_enum = models.CharField(max_length=80, blank=True, null=True)
     chron = models.CharField(max_length=80, blank=True, null=True)
     year = models.CharField(max_length=20, blank=True, null=True)
@@ -962,13 +1467,18 @@ class MfhdItem(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'mfhd_item'
-        unique_together = (('item_id', 'mfhd_id'), ('mfhd_id', 'item_id'),)
+        db_table = "mfhd_item"
+        unique_together = (
+            ("item_id", "mfhd_id"),
+            ("mfhd_id", "item_id"),
+        )
 
 
 class MfhdMaster(models.Model):
     mfhd_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     call_no_type = models.CharField(max_length=1, blank=True, null=True)
     normalized_call_no = models.CharField(max_length=300, blank=True, null=True)
     display_call_no = models.CharField(max_length=300, blank=True, null=True)
@@ -984,12 +1494,14 @@ class MfhdMaster(models.Model):
     export_ok = models.CharField(max_length=1, blank=True, null=True)
     export_ok_date = models.DateTimeField(blank=True, null=True)
     export_ok_opid = models.CharField(max_length=10, blank=True, null=True)
-    export_ok_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    export_ok_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     export_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'mfhd_master'
+        db_table = "mfhd_master"
 
 
 class MfhdRecord(models.Model):
@@ -998,7 +1510,7 @@ class MfhdRecord(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'mfhd_record'
+        db_table = "mfhd_record"
 
 
 class NoFillReason(models.Model):
@@ -1009,7 +1521,7 @@ class NoFillReason(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'no_fill_reason'
+        db_table = "no_fill_reason"
 
 
 class NoteType(models.Model):
@@ -1018,7 +1530,7 @@ class NoteType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'note_type'
+        db_table = "note_type"
 
 
 class Operator(models.Model):
@@ -1034,12 +1546,14 @@ class Operator(models.Model):
     manual_expire = models.CharField(max_length=1)
     invalid_login_time = models.DateTimeField(blank=True, null=True)
     lockout_time = models.DateTimeField(blank=True, null=True)
-    lockout_counter = models.DecimalField(max_digits=22, decimal_places=0, blank=True, null=True)
+    lockout_counter = models.DecimalField(
+        max_digits=22, decimal_places=0, blank=True, null=True
+    )
     restrict_password_change = models.CharField(max_length=1)
 
     class Meta:
         managed = False
-        db_table = 'operator'
+        db_table = "operator"
 
 
 class OrderTypes(models.Model):
@@ -1048,12 +1562,14 @@ class OrderTypes(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'order_types'
+        db_table = "order_types"
 
 
 class Patron(models.Model):
     patron_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    name_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    name_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     last_name = models.CharField(max_length=50, blank=True, null=True)
     normal_last_name = models.CharField(max_length=50, blank=True, null=True)
     first_name = models.CharField(max_length=50, blank=True, null=True)
@@ -1066,53 +1582,117 @@ class Patron(models.Model):
     normal_institution_id = models.CharField(max_length=30, blank=True, null=True)
     registration_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    home_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    home_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    modify_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    modify_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     modify_date = models.DateTimeField(blank=True, null=True)
     expire_date = models.DateTimeField(blank=True, null=True)
     purge_date = models.DateTimeField(blank=True, null=True)
-    current_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    total_fees_due = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    note_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    current_hold_shelf = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    recalls_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    holds_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    items_recalled = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    claims_return = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    lost_items = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    self_shelved = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    current_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    total_fees_due = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    note_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    current_hold_shelf = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    recalls_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    holds_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    items_recalled = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    claims_return = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    lost_items = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    self_shelved = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     counter_reset_date = models.DateTimeField(blank=True, null=True)
     counter_reset_oper_id = models.CharField(max_length=10, blank=True, null=True)
-    current_bookings = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    late_media_returns = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_bookings = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    cancelled_bookings = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    unclaimed_bookings = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    current_bookings = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    late_media_returns = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_bookings = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    cancelled_bookings = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    unclaimed_bookings = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     media_counter_reset_date = models.DateTimeField(blank=True, null=True)
     media_counter_reset_opid = models.CharField(max_length=10, blank=True, null=True)
-    current_call_slips = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_call_slips = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_distributions = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    current_call_slips = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_call_slips = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_distributions = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     current_short_loans = models.BigIntegerField(blank=True, null=True)
     historical_short_loans = models.BigIntegerField(blank=True, null=True)
     unclaimed_short_loans = models.BigIntegerField(blank=True, null=True)
     db_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    current_charges_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_charges_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    requests_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_requests_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    claims_return_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    lost_items_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    total_fees_due_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    self_shelved_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_id_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    current_charges_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_charges_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    requests_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_requests_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    claims_return_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    lost_items_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    total_fees_due_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    self_shelved_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_pin = models.CharField(max_length=12, blank=True, null=True)
     suspension_date = models.DateTimeField(blank=True, null=True)
-    total_demerits = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    total_demerits_due_ub = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    total_demerits = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    total_demerits_due_ub = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     sms_number = models.CharField(max_length=50, blank=True, null=True)
     birth_date = models.DateTimeField(blank=True, null=True)
     major = models.CharField(max_length=50, blank=True, null=True)
@@ -1120,13 +1700,19 @@ class Patron(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'patron'
+        db_table = "patron"
 
 
 class PatronAddress(models.Model):
-    address_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    address_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    address_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    address_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     address_status = models.CharField(max_length=1, blank=True, null=True)
     protect_address = models.CharField(max_length=1, blank=True, null=True)
     address_line1 = models.CharField(max_length=100, blank=True, null=True)
@@ -1145,50 +1731,72 @@ class PatronAddress(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'patron_address'
+        db_table = "patron_address"
 
 
 class PatronBarcode(models.Model):
-    patron_barcode_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_barcode_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_barcode = models.CharField(max_length=25, blank=True, null=True)
-    barcode_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    barcode_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     barcode_status_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
-    home_barcode_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    home_patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    home_barcode_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    home_patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'patron_barcode'
+        db_table = "patron_barcode"
 
 
 class PatronBarcodeStatus(models.Model):
-    barcode_status_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    barcode_status_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     barcode_status_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_barcode_status'
+        db_table = "patron_barcode_status"
 
 
 class PatronGroup(models.Model):
-    patron_group_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_group_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_group_code = models.CharField(max_length=10, blank=True, null=True)
     patron_group_name = models.CharField(max_length=25, blank=True, null=True)
     patron_group_display = models.CharField(max_length=40, blank=True, null=True)
     demerits_applies = models.CharField(max_length=1, blank=True, null=True)
-    max_demerits = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    suspension_days = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    circ_cluster_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    max_demerits = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    suspension_days = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    circ_cluster_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     charged_status_display = models.CharField(max_length=1, blank=True, null=True)
     charge_limit = models.BigIntegerField(blank=True, null=True)
     charge_limit_apply = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_group'
+        db_table = "patron_group"
 
 
 class PatronGroupItemType(models.Model):
@@ -1198,30 +1806,52 @@ class PatronGroupItemType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'patron_group_item_type'
+        db_table = "patron_group_item_type"
 
 
 class PatronGroupPolicy(models.Model):
-    circ_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_group_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    circ_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_group_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     fees_applies = models.CharField(max_length=1, blank=True, null=True)
-    max_outstanding_balance = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    max_outstanding_balance = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     overdue_notice_applies = models.CharField(max_length=1, blank=True, null=True)
-    min_balance_for_notice = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    min_balance_for_notice = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_item_limit = models.CharField(max_length=1, blank=True, null=True)
-    item_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_overdue_limit = models.CharField(max_length=1, blank=True, null=True)
-    overdue_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overdue_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_overdue_recall_limit = models.CharField(max_length=1, blank=True, null=True)
-    overdue_recall_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    overdue_recall_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_recall_limit = models.CharField(max_length=1, blank=True, null=True)
-    recall_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    recall_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_self_shelve_limit = models.CharField(max_length=1, blank=True, null=True)
-    self_shelve_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    self_shelve_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_claim_return_limit = models.CharField(max_length=1, blank=True, null=True)
-    claim_return_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    claim_return_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_lost_limit = models.CharField(max_length=1, blank=True, null=True)
-    lost_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    lost_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     place_hold_outside_lib = models.CharField(max_length=1, blank=True, null=True)
     place_hold_inside_lib = models.CharField(max_length=1, blank=True, null=True)
     place_recall_outside_lib = models.CharField(max_length=1, blank=True, null=True)
@@ -1229,7 +1859,9 @@ class PatronGroupPolicy(models.Model):
     place_interlib_loan_req = models.CharField(max_length=1, blank=True, null=True)
     place_purchase_req = models.CharField(max_length=1, blank=True, null=True)
     courtesy_notice_applies = models.CharField(max_length=1, blank=True, null=True)
-    call_slip_limit = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    call_slip_limit = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     max_call_slips = models.CharField(max_length=1, blank=True, null=True)
     place_call_slips = models.CharField(max_length=1, blank=True, null=True)
     email_courtesy_notice = models.CharField(max_length=1, blank=True, null=True)
@@ -1252,63 +1884,87 @@ class PatronGroupPolicy(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'patron_group_policy'
+        db_table = "patron_group_policy"
 
 
 class PatronNameType(models.Model):
-    patron_name_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_name_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     patron_name_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_name_type'
+        db_table = "patron_name_type"
 
 
 class PatronNotes(models.Model):
-    patron_note_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    note_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    address_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_note_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    note_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    address_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     note = models.CharField(max_length=1900, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_notes'
+        db_table = "patron_notes"
 
 
 class PatronPhone(models.Model):
-    patron_phone_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
-    address_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    phone_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_phone_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    address_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    phone_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     phone_number = models.CharField(max_length=25, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_phone'
+        db_table = "patron_phone"
 
 
 class PatronStatCode(models.Model):
-    patron_stat_id = models.DecimalField(unique=True, max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_stat_code = models.CharField(unique=True, max_length=3, blank=True, null=True)
+    patron_stat_id = models.DecimalField(
+        unique=True, max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_stat_code = models.CharField(
+        unique=True, max_length=3, blank=True, null=True
+    )
     patron_stat_desc = models.CharField(max_length=25, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_stat_code'
+        db_table = "patron_stat_code"
 
 
 class PatronStats(models.Model):
-    patron_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_stat_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_stat_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     date_applied = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'patron_stats'
+        db_table = "patron_stats"
 
 
 class PhoneType(models.Model):
@@ -1317,22 +1973,34 @@ class PhoneType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'phone_type'
+        db_table = "phone_type"
 
 
 class PoFunds(models.Model):
     po_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ledger_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    fund_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commit_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    commitments = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expend_pending = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    expenditures = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    ledger_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    fund_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commit_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    commitments = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expend_pending = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    expenditures = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'po_funds'
-        unique_together = (('po_id', 'ledger_id', 'fund_id'),)
+        db_table = "po_funds"
+        unique_together = (("po_id", "ledger_id", "fund_id"),)
 
 
 class PoNotes(models.Model):
@@ -1342,7 +2010,7 @@ class PoNotes(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'po_notes'
+        db_table = "po_notes"
 
 
 class PoStatus(models.Model):
@@ -1351,7 +2019,7 @@ class PoStatus(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'po_status'
+        db_table = "po_status"
 
 
 class PoType(models.Model):
@@ -1360,86 +2028,142 @@ class PoType(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'po_type'
+        db_table = "po_type"
 
 
 class PriceAdjustment(models.Model):
     object_type = models.CharField(max_length=1, blank=True, null=True)
-    object_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    sequence = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    reason_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    object_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    sequence = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    reason_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     method = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    adjust_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    payment_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    adjust_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    payment_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'price_adjustment'
-        unique_together = (('object_type', 'object_id', 'sequence'),)
+        db_table = "price_adjustment"
+        unique_together = (("object_type", "object_id", "sequence"),)
 
 
 class ProxyPatron(models.Model):
-    patron_barcode_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    patron_barcode_id_proxy = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    patron_barcode_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    patron_barcode_id_proxy = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
-    create_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     expiration_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'proxy_patron'
+        db_table = "proxy_patron"
 
 
 class PurchaseOrder(models.Model):
     po_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    account_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    po_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    account_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    po_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     po_number = models.CharField(max_length=25, blank=True, null=True)
     normal_po_number = models.CharField(max_length=25, blank=True, null=True)
-    order_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    ship_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    bill_location = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    order_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    ship_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    bill_location = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     currency_code = models.CharField(max_length=3, blank=True, null=True)
-    conversion_rate = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    po_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    conversion_rate = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    po_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     po_status_date = models.DateTimeField(blank=True, null=True)
     po_create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
     po_update_date = models.DateTimeField(blank=True, null=True)
     update_opid = models.CharField(max_length=10, blank=True, null=True)
-    create_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    update_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    create_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    update_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     ship_via = models.CharField(max_length=20, blank=True, null=True)
     not_needed_after = models.DateTimeField(blank=True, null=True)
     rush = models.CharField(max_length=1, blank=True, null=True)
-    claim_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    cancel_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_subtotal = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    adjustments_subtotal = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    claim_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    cancel_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_subtotal = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    adjustments_subtotal = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     total = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    edi_ref = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    edi_ref = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     po_approve_date = models.DateTimeField(blank=True, null=True)
     approve_opid = models.CharField(max_length=10, blank=True, null=True)
-    approve_location_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    prepay_conversion_rate = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    approve_location_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    prepay_conversion_rate = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'purchase_order'
+        db_table = "purchase_order"
 
 
 class ReserveItemHistory(models.Model):
-    item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     effect_date = models.DateTimeField(blank=True, null=True)
     expire_date = models.DateTimeField(blank=True, null=True)
-    reserve_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    reserve_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False
-        db_table = 'reserve_item_history'
+        db_table = "reserve_item_history"
 
 
 class Vendor(models.Model):
@@ -1453,9 +2177,15 @@ class Vendor(models.Model):
     federal_tax_id = models.CharField(max_length=10, blank=True, null=True)
     institution_id = models.CharField(max_length=25, blank=True, null=True)
     default_currency = models.CharField(max_length=3, blank=True, null=True)
-    claim_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    claim_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    cancel_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    claim_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    claim_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    cancel_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     ship_via = models.CharField(max_length=20, blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_opid = models.CharField(max_length=10, blank=True, null=True)
@@ -1464,28 +2194,38 @@ class Vendor(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'vendor'
+        db_table = "vendor"
 
 
 class VendorAccount(models.Model):
     account_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     account_number = models.CharField(max_length=25, blank=True, null=True)
     account_name = models.CharField(max_length=25, blank=True, null=True)
-    default_po_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    default_po_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     deposit = models.CharField(max_length=1, blank=True, null=True)
-    default_discount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    account_status = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    default_discount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    account_status = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     status_date = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'vendor_account'
+        db_table = "vendor_account"
 
 
 class VendorAddress(models.Model):
     address_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     std_address_number = models.CharField(max_length=8, blank=True, null=True)
     order_address = models.CharField(max_length=1, blank=True, null=True)
     payment_address = models.CharField(max_length=1, blank=True, null=True)
@@ -1509,7 +2249,7 @@ class VendorAddress(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'vendor_address'
+        db_table = "vendor_address"
 
 
 class VendorBankInfo(models.Model):
@@ -1534,7 +2274,7 @@ class VendorBankInfo(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'vendor_bank_info'
+        db_table = "vendor_bank_info"
 
 
 class VendorNote(models.Model):
@@ -1543,20 +2283,24 @@ class VendorNote(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'vendor_note'
+        db_table = "vendor_note"
 
 
 class VendorPhone(models.Model):
-    address_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    phone_type = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    address_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    phone_type = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     phone_number = models.CharField(max_length=25, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'vendor_phone'
-        unique_together = (('address_id', 'phone_type', 'phone_number'),)
+        db_table = "vendor_phone"
+        unique_together = (("address_id", "phone_type", "phone_number"),)
 
 
 class VendorTypes(models.Model):
@@ -1565,7 +2309,7 @@ class VendorTypes(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'vendor_types'
+        db_table = "vendor_types"
 
 
 class ItemView(models.Model):
@@ -1581,26 +2325,40 @@ class ItemView(models.Model):
     temp_location = models.CharField(max_length=10, blank=True, null=True)
     item_type = models.CharField(max_length=25, blank=True, null=True)
     temp_item_type = models.CharField(max_length=25, blank=True, null=True)
-    copy_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    copy_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     on_reserve = models.CharField(max_length=1, blank=True, null=True)
-    reserve_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    reserve_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     pieces = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     price = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_charges = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    historical_browses = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    recalls_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    holds_placed = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    historical_charges = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    historical_browses = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    recalls_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    holds_placed = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
     create_location = models.CharField(max_length=10, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
     modify_operator_id = models.CharField(max_length=10, blank=True, null=True)
     modify_location = models.CharField(max_length=10, blank=True, null=True)
-    item_sequence_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    item_sequence_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'item_view'
+        db_table = "item_view"
 
 
 class VendorView(models.Model):
@@ -1612,9 +2370,15 @@ class VendorView(models.Model):
     federal_tax_id = models.CharField(max_length=10, blank=True, null=True)
     vendor_note = models.CharField(max_length=1900, blank=True, null=True)
     default_currency = models.CharField(max_length=3, blank=True, null=True)
-    claim_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    claim_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    cancel_interval = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    claim_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    claim_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    cancel_interval = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
     modify_date = models.DateTimeField(blank=True, null=True)
@@ -1622,12 +2386,16 @@ class VendorView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'vendor_view'
+        db_table = "vendor_view"
 
 
 class VendorAccountView(models.Model):
-    vendor_account_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_account_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     account_number = models.CharField(max_length=25, blank=True, null=True)
     account_name = models.CharField(max_length=25, blank=True, null=True)
     deposit = models.CharField(max_length=1, blank=True, null=True)
@@ -1635,12 +2403,14 @@ class VendorAccountView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'vendor_account_view'
+        db_table = "vendor_account_view"
 
 
 class InvoiceHeaderView(models.Model):
     invoice_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     vendor_code = models.CharField(max_length=10, blank=True, null=True)
     vendor_acccount_number = models.CharField(max_length=25, blank=True, null=True)
     invoice_number = models.CharField(max_length=25, blank=True, null=True)
@@ -1648,13 +2418,25 @@ class InvoiceHeaderView(models.Model):
     status = models.CharField(max_length=25, blank=True, null=True)
     status_date = models.DateTimeField(blank=True, null=True)
     voucher_number = models.CharField(max_length=25, blank=True, null=True)
-    line_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     currency_code = models.CharField(max_length=3, blank=True, null=True)
-    conversion_rate = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    invoice_total = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    line_item_subtotal = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    adjustments_subtotal = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    total = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
+    conversion_rate = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    invoice_total = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    line_item_subtotal = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    adjustments_subtotal = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    total = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
     create_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
     create_location = models.CharField(max_length=10, blank=True, null=True)
@@ -1664,16 +2446,22 @@ class InvoiceHeaderView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'invoice_header_view'
+        db_table = "invoice_header_view"
 
 
 class InvoiceAdjustmentView(models.Model):
     payment_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    invoice_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    invoice_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     description = models.CharField(max_length=50, blank=True, null=True)
     currency_code = models.CharField(max_length=3, blank=True, null=True)
-    raw_amount = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    usd_amount = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
+    raw_amount = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    usd_amount = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
     ledger_name = models.CharField(max_length=40, blank=True, null=True)
     fund_name = models.CharField(max_length=25, blank=True, null=True)
     fund_code = models.CharField(max_length=10, blank=True, null=True)
@@ -1681,22 +2469,42 @@ class InvoiceAdjustmentView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'invoice_adjustment_view'
+        db_table = "invoice_adjustment_view"
 
 
 # TODO: May need better primary key as inv_line_item_id will sometimes be repeated...
 class InvoiceLineView(models.Model):
-    inv_line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    invoice_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    line_item_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    copy_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    unit_price = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    line_price = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    quantity = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    inv_line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    invoice_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    line_item_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    copy_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    unit_price = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    line_price = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    quantity = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     piece_identifier = models.CharField(max_length=500, blank=True, null=True)
-    split_fund_seq = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    percentage = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    usd_amount = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
+    split_fund_seq = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    percentage = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    usd_amount = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
     ledger_name = models.CharField(max_length=40, blank=True, null=True)
     fund_name = models.CharField(max_length=25, blank=True, null=True)
     fund_code = models.CharField(max_length=10, blank=True, null=True)
@@ -1708,17 +2516,21 @@ class InvoiceLineView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'invoice_line_view'
+        db_table = "invoice_line_view"
 
 
 class PoHeaderView(models.Model):
     po_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    vendor_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    vendor_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     vendor_code = models.CharField(max_length=10, blank=True, null=True)
     vendor_acccount_number = models.CharField(max_length=25, blank=True, null=True)
     po_number = models.CharField(max_length=25, blank=True, null=True)
     currency_code = models.CharField(max_length=3, blank=True, null=True)
-    conversion_rate = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    conversion_rate = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     po_type = models.CharField(max_length=25, blank=True, null=True)
     po_status = models.CharField(max_length=25, blank=True, null=True)
     status_date = models.DateTimeField(blank=True, null=True)
@@ -1727,11 +2539,19 @@ class PoHeaderView(models.Model):
     order_location = models.CharField(max_length=10, blank=True, null=True)
     ship_location = models.CharField(max_length=10, blank=True, null=True)
     bill_location = models.CharField(max_length=10, blank=True, null=True)
-    line_item_count = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_count = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     note = models.CharField(max_length=1900, blank=True, null=True)
-    line_item_subtotal = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    adjustments_subtotal = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    total = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
+    line_item_subtotal = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    adjustments_subtotal = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    total = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
     create_location = models.CharField(max_length=10, blank=True, null=True)
     create_date = models.DateTimeField(blank=True, null=True)
     create_operator_id = models.CharField(max_length=10, blank=True, null=True)
@@ -1741,31 +2561,54 @@ class PoHeaderView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'po_header_view'
+        db_table = "po_header_view"
 
 
 # TODO: May need better primary key as line_item_id will sometimes be repeated...
 class PoLineItemView(models.Model):
-    line_item_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
+    line_item_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
     po_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
     bib_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    copy_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    mfhd_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    copy_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    mfhd_id = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    title = models.TextField(blank=True, null=True)
     location_code = models.CharField(max_length=10, blank=True, null=True)
     po_number = models.CharField(max_length=25, blank=True, null=True)
     line_item_type = models.CharField(max_length=25, blank=True, null=True)
     line_item_status = models.CharField(max_length=25, blank=True, null=True)
     inv_line_status = models.CharField(max_length=25, blank=True, null=True)
     status_date = models.DateTimeField(blank=True, null=True)
-    line_item_number = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    line_item_number = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     piece_identifier = models.CharField(max_length=50, blank=True, null=True)
-    unit_price = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    line_price = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    split_fund_seq = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    percentage = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    raw_amount = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
-    usd_amount = models.DecimalField(max_digits=65535, decimal_places=65535, blank=True, null=True)
-    quantity = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    unit_price = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    line_price = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    split_fund_seq = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    percentage = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    raw_amount = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
+    usd_amount = models.DecimalField(
+        max_digits=65535, decimal_places=65535, blank=True, null=True
+    )
+    quantity = models.DecimalField(
+        max_digits=38, decimal_places=0, blank=True, null=True
+    )
     ledger_name = models.CharField(max_length=40, blank=True, null=True)
     fund_name = models.CharField(max_length=25, blank=True, null=True)
     fund_code = models.CharField(max_length=10, blank=True, null=True)
@@ -1783,4 +2626,4 @@ class PoLineItemView(models.Model):
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
-        db_table = 'po_line_item_view'
+        db_table = "po_line_item_view"

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -36,3 +36,7 @@
   .delimiter {
     color: blue
   }
+
+  .label {
+    font-weight: bold;
+  }

--- a/voyager_archive/templates/voyager_archive/po_display.html
+++ b/voyager_archive/templates/voyager_archive/po_display.html
@@ -1,0 +1,131 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+<form name="search_archive" id="search_archive" method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    <table>
+        {{ form.as_table }}
+    </table>
+    <br>
+    <button type="submit">Search</button>
+</form>
+<hr>
+
+<h2>Purchase Order Header</h2>
+<div class="row">
+    <div class="column">
+        <table class="data-display">
+            <tr>
+                <td class="label">PO Number</td>
+                <td>{{ po_header.po_number }}</td>
+            </tr>
+            <tr>
+                <td class="label">Vendor</td>
+                <td>
+                    {{ po_header.vendor_code }}
+                    {% if po_header.vendor_account_number %}(account {{po_header.vendor_account_number }}){% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="label">PO Type</td>
+                <td>{{ po_header.po_type }}</td>
+            </tr>
+            <tr>
+                <td class="label">PO Status</td>
+                <td>{{ po_header.po_status}} ({{ po_header.status_date }})</td>
+            </tr>
+            <tr>
+                <td class="label">Approved</td>
+                <td>{{ po_header.approve_date }} by {{ po_header.approve_operator_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Created</td>
+                <td>{{ po_header.create_date }} by {{ po_header.create_operator_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Modified</td>
+                <td>{{ po_header.modify_date }} by {{ po_header.modify_operator_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Note</td>
+                <td>{{ po_header.note }}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="column">
+        <table class="data-display">
+            <tr>
+                <td class="label">Order Location</td>
+                <td>{{ po_header.order_location }}</td>
+            </tr>
+            <tr>
+                <td class="label">Shipping Location</td>
+                <td>{{ po_header.ship_location }}</td>
+            </tr>
+            <tr>
+                <td class="label">Billing Location</td>
+                <td>{{ po_header.bill_location }}</td>
+            </tr>
+            <tr>
+                <td class="label">Original Currency</td>
+                <td>
+                    {% if po_header.currency_code == "USD" %}
+                    USD
+                    {% else %}
+                    {{ po_header.currency_code }} (1 USD = {{ po_header.conversion_rate|floatformat:2 }} {{ po_header.currency_code }})
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <td class="label">Line Item Subtotal</td>
+                <td>USD ${{ po_header.line_item_subtotal|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Adjustments Subtotal</td>
+                <td>USD ${{ po_header.adjustments_subtotal|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Total</td>
+                <td>USD ${{ po_header.total|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Line Items</td>
+                <td>{{ po_header.line_item_count }}</td>
+            </tr>
+        </table>        
+    </div>
+</div>
+
+<div class="row">
+    <div class="column">
+        {% if po_lines %}
+        <h2>Purchase Order Lines</h2>
+        {% for line in po_lines %}
+        <table class="data-display">
+            <tr>
+                <th>Line #</th>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Piece Identifier</th>
+                <th>Amount</th>
+            </tr>
+            <tr>
+                <td class="label">#{{ line.line_item_number }}</td>
+                <td>{{ line.bib_id }} {{ line.title }}</td>
+                <td>{{ line.line_item_status }} / {{ line.inv_line_status }} ({{ line.status_date }})</td>
+                <td>{% if line.piece_identifer %}{{ line.piece_identifier }}{% endif %}</td>
+                <td>USD ${{ line.usd_amount|floatformat:2 }}</td>
+            </tr>
+            {% comment %}
+            <tr>
+                <td class="label"></td>
+                <td></td>
+            </tr>
+            {% endcomment %}
+        </table>
+        {% endfor %}
+        {% endif %}
+    </div>
+</div>
+
+{% endblock %}

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -1,7 +1,7 @@
 from http.client import INTERNAL_SERVER_ERROR
 import logging
 from django.shortcuts import render
-from django.http.request import HttpRequest # for code completion
+from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse
 from .forms import VoyArchiveForm
 from .views_utils import *
@@ -11,54 +11,45 @@ logger = logging.getLogger(__name__)
 
 
 def search(request: HttpRequest) -> None:
-    if request.method == 'POST':
+    if request.method == "POST":
         form = VoyArchiveForm(request.POST)
         if form.is_valid():
             # Do stuff, using form.cleaned_data['search_type'] and form.cleaned_data['search_term']
-            logger.info(f'Form data: {form.cleaned_data}')
-            search_type = form.cleaned_data['search_type']
-            search_term = form.cleaned_data['search_term']
+            logger.info(f"Form data: {form.cleaned_data}")
+            search_type = form.cleaned_data["search_type"]
+            search_term = form.cleaned_data["search_term"]
 
             marc_record = None
             item = None
+            po_header = None
             vendor = None
-            vendor_acct_list = None
-            if search_type == 'AUTH_ID':
+            if search_type == "AUTH_ID":
                 marc_record = get_auth_record(search_term)
-            elif search_type == 'BIB_ID':
+            elif search_type == "BIB_ID":
                 marc_record = get_bib_record(search_term)
-            elif search_type == 'MFHD_ID':
+            elif search_type == "MFHD_ID":
                 marc_record = get_mfhd_record(search_term)
-            elif search_type == 'ITEM_BARCODE':
+            elif search_type == "ITEM_BARCODE":
                 item = get_item(search_term)
-            elif search_type == 'VENDOR_CODE':
+            elif search_type == "PO_NUMBER":
+                po_header = get_po_header(search_term)
+                po_lines = get_po_lines(po_header.po_id)
+            elif search_type == "VENDOR_CODE":
                 vendor = get_vendor(search_term)
                 vendor_accts = get_vendor_accts(vendor.vendor_id)
 
             if marc_record:
-                context = {
-                    'form': form,
-                    'marc_record': marc_record
-                }
-
-                return render(request, 'voyager_archive/marc_display.html', context)
-            
+                context = {"form": form, "marc_record": marc_record}
+                return render(request, "voyager_archive/marc_display.html", context)
             elif item:
-                context = {
-                    'form': form,
-                    'item': item
-                }
-
-                return render(request, 'voyager_archive/item_display.html', context)
-            
+                context = {"form": form, "item": item}
+                return render(request, "voyager_archive/item_display.html", context)
+            elif po_header:
+                context = {"form": form, "po_header": po_header, "po_lines": po_lines}
+                return render(request, "voyager_archive/po_display.html", context)
             elif vendor:
-                context = {
-                    'form': form,
-                    'vendor': vendor,
-                    'vendor_accts': vendor_accts
-                }
-
-                return render(request, 'voyager_archive/vendor_display.html', context)
+                context = {"form": form, "vendor": vendor, "vendor_accts": vendor_accts}
+                return render(request, "voyager_archive/vendor_display.html", context)
     else:
         form = VoyArchiveForm()
-        return render(request, 'voyager_archive/search.html', {'form': form})
+        return render(request, "voyager_archive/search.html", {"form": form})

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,24 +1,30 @@
 from django.shortcuts import get_object_or_404
 from pymarc import Record
 from django.db.models import QuerySet
-from .models import AuthRecord, BibRecord, MfhdRecord, ItemView, VendorView, VendorAccountView
+from .models import (
+    AuthRecord,
+    BibRecord,
+    MfhdRecord,
+    ItemView,
+    PoHeaderView,
+    PoLineItemView,
+    VendorView,
+    VendorAccountView,
+)
 
 
 def get_auth_record(auth_id: int) -> dict:
     marc_text = get_object_or_404(AuthRecord, auth_id=auth_id).auth_record
-
     return get_marc_fields(marc_text)
 
 
 def get_bib_record(bib_id: int) -> dict:
     marc_text = get_object_or_404(BibRecord, bib_id=bib_id).bib_record
-
     return get_marc_fields(marc_text)
 
 
 def get_mfhd_record(mfhd_id: int) -> dict:
     marc_text = get_object_or_404(MfhdRecord, mfhd_id=mfhd_id).mfhd_record
-
     return get_marc_fields(marc_text)
 
 
@@ -26,7 +32,6 @@ def get_marc_fields(marc_text: str) -> dict:
     byte_obj = marc_text.encode("utf-8")
     marc_record = Record(data=byte_obj)
     marc_fields = marc_record.get_fields()
-
     marc_field_list = []
     marc_record_dict = {}
     marc_record_dict["leader"] = marc_record.leader
@@ -48,7 +53,6 @@ def get_marc_fields(marc_text: str) -> dict:
             for delim in subfield_default_dict.keys():
                 subfield_dict[delim] = subfield_default_dict[delim]
             tmp_rec_dict["subfields"] = subfield_dict
-
         except Exception as e:
             # If subfields don't exist an exception is thrown
             pass
@@ -56,21 +60,29 @@ def get_marc_fields(marc_text: str) -> dict:
         marc_field_list.append(tmp_rec_dict)
 
     marc_record_dict["fields"] = marc_field_list
-
     return marc_record_dict
 
 
 def get_item(item_barcode: str) -> ItemView:
     item = get_object_or_404(ItemView, item_barcode=item_barcode)
-
     return item
+
 
 def get_vendor(vendor_code: str) -> VendorView:
     vendor = get_object_or_404(VendorView, vendor_code=vendor_code)
-
     return vendor
+
 
 def get_vendor_accts(vendor_id: int) -> QuerySet:
     vendor_accts = VendorAccountView.objects.filter(vendor_id=vendor_id)
-
     return vendor_accts
+
+
+def get_po_header(po_number: str) -> PoHeaderView:
+    purchase_order = get_object_or_404(PoHeaderView, po_number=po_number)
+    return purchase_order
+
+
+def get_po_lines(po_id: int) -> QuerySet:
+    po_lines = PoLineItemView.objects.filter(po_id=po_id)
+    return po_lines


### PR DESCRIPTION
Related to [SYS-983](https://jira.library.ucla.edu/browse/SYS-983)

This PR allows users to search by purchase order number, and displays data from the PO header and PO line items.
It also:
* Adds a new table `bib_title` which provides brief titles for display in PO lines (and invoice lines, later)
* Adds `bib_title.title` to `PoLineItemView` model and the underlying database view
* Fixes an error in `conversion_rate` in `PoLineItemView`
* Adds sample data allowing 1 line item to display for each sample purchase order
* Adds a `label` CSS class for styling table cells containing labels (separate from `<th>` table header cells)
* Updates python code in touched files via [Black](https://black.readthedocs.io/en/stable/) formatter

Testing: 
* Restart docker-compose system, if running
* Run: `sql_support/initialize_database.sh`
* Search for PO Number: `EAL518017` and `MUS522069`.  Each PO should display with one PO line, which is all I included in sample data.
