### PR TITLE
SYS-1030: Apply label CSS class to vendor and item templates

### DIFF
--- a/voyager_archive/templates/voyager_archive/item_display.html
+++ b/voyager_archive/templates/voyager_archive/item_display.html
@@ -9,134 +9,134 @@
     <br>
     <button type="submit">Search</button>
 </form>
-<hr/>
+<hr>
 
 
 <div class="row">
     <div class="column">
-        <h1>Basic Information</h1>
+        <h2>Basic Information</h2>
         <table class="data-display">
             <tr>
-                <td>Item Barcode</td>
+                <td class="label">Item Barcode</td>
                 <td>{{ item.item_barcode }}</td>
             </tr>
             <tr>
-                <td>Item ID</td>
+                <td class="label">Item ID</td>
                 <td>{{ item.item_id }}</td>
             </tr>
             <tr>
-                <td>MFHD ID</td>
+                <td class="label">MFHD ID</td>
                 <td>{{ item.mfhd_id }}</td>
             </tr>
             <tr>
-                <td>Item Type</td>
+                <td class="label">Item Type</td>
                 <td>{{ item.item_type }}</td>
             </tr>
             <tr>
-                <td>Temporary Item Type</td>
+                <td class="label">Temporary Item Type</td>
                 <td>{{ item.temp_item_type }}</td>
             </tr>
             <tr>
-                <td>Enumeration</td>
+                <td class="label">Enumeration</td>
                 <td>{{ item.item_enum }}</td>
             </tr>
             <tr>
-                <td>Chronology</td>
+                <td class="label">Chronology</td>
                 <td>{{ item.chron }}</td>
             </tr>
             <tr>
-                <td>Year</td>
+                <td class="label">Year</td>
                 <td>{{ item.year }}</td>
             </tr>
             <tr>
-                <td>Caption</td>
+                <td class="label">Caption</td>
                 <td>{{ item.caption }}</td>
             </tr>
             <tr>
-                <td>Freetext</td>
+                <td class="label">Freetext</td>
                 <td>{{ item.freetext }}</td>
             </tr>
             <tr>
-                <td>Copy Number</td>
+                <td class="label">Copy Number</td>
                 <td>{{ item.copy_number }}</td>
             </tr>
             <tr>
-                <td>Pieces</td>
+                <td class="label">Pieces</td>
                 <td>{{ item.pieces }}</td>
             </tr>
             <tr>
-                <td>Price</td>
+                <td class="label">Price</td>
                 <td>{{ item.price }}</td>
             </tr>
             <tr>
-                <td>Item Sequence Number</td>
+                <td class="label">Item Sequence Number</td>
                 <td>{{ item.item_sequence_number }}</td>
             </tr>
 
         </table>
     </div>
     <div class="column">
-        <h1>Location and Circulation Information</h1>
+        <h2>Location and Circulation Information</h2>
         <table class="data-display">
             <tr>
-                <td>Permanent Location</td>
+                <td class="label">Permanent Location</td>
                 <td>{{ item.perm_location }}</td>
             </tr>
             <tr>
-                <td>Temporary Location</td>
+                <td class="label">Temporary Location</td>
                 <td>{{ item.temp_location }}</td>
             </tr>
             <tr>
-                <td>Historical Charges</td>
+                <td class="label">Historical Charges</td>
                 <td>{{ item.historical_charges }}</td>
             </tr>
             <tr>
-                <td>Historical Browses</td>
+                <td class="label">Historical Browses</td>
                 <td>{{ item.historical_browses }}</td>
             </tr>
             <tr>
-                <td>Holds Placed</td>
+                <td class="label">Holds Placed</td>
                 <td>{{ item.holds_placed }}</td>
             </tr>
             <tr>
-                <td>Recalls Placed</td>
+                <td class="label">Recalls Placed</td>
                 <td>{{ item.recalls_placed }}</td>
             </tr>
             <tr>
-                <td>On Reserve</td>
+                <td class="label">On Reserve</td>
                 <td>{{ item.on_reserve }}</td>
             </tr>
             <tr>
-                <td>Reserve Charges</td>
+                <td class="label">Reserve Charges</td>
                 <td>{{ item.reserve_charges }}</td>
             </tr>
         </table>
     </div>
     <div class="column">
-        <h1>Metadata Information</h1>
+        <h2>Metadata Information</h2>
         <table class="data-display">
             <tr>
-                <td>Creator ID</td>
+                <td class="label">Creator ID</td>
                 <td>{{ item.create_operator_id }}</td>
             </tr>
             <tr>
-                <td>Creation Date</td>
+                <td class="label">Creation Date</td>
                 <td>{{ item.create_date }}</td>
             </tr>
             <tr>
-                <td>Creation Location</td>
+                <td class="label">Creation Location</td>
                 <td>{{ item.create_location }}</td>
             </tr>
             <tr>
-                <td>Modifier ID</td>
+                <td class="label">Modifier ID</td>
                 <td>{{ item.modify_operator_id }}</td>
             </tr>
             <tr>
-                <td>Modification Date</td>
+                <td class="label">Modification Date</td>
                 <td>{{ item.modify_date }}</td>
             </tr>
             <tr>
-                <td>Modification Location</td>
+                <td class="label">Modification Location</td>
                 <td>{{ item.modify_location }}</td>
             </tr>
         </table>

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -14,70 +14,70 @@
 
 <div class="row">
     <div class="column">
-        <h1>Vendor Information</h1>
+        <h2>Vendor Information</h2>
         <table class="data-display">
             <tr>
-                <td>Vendor Code</td>
+                <td class="label">Vendor Code</td>
                 <td>{{ vendor.vendor_code }}</td>
             </tr>
             <tr>
-                <td>Vendor Name</td>
+                <td class="label">Vendor Name</td>
                 <td>{{ vendor.vendor_name }}</td>
             </tr>
             <tr>
-                <td>Vendor ID</td>
+                <td class="label">Vendor ID</td>
                 <td>{{ vendor.vendor_id }}</td>
             </tr>
             <tr>
-                <td>Vendor Type</td>
+                <td class="label">Vendor Type</td>
                 <td>{{ vendor.vendor_type }}</td>
             </tr>
             <tr>
-                <td>Institution ID</td>
+                <td class="label">Institution ID</td>
                 <td>{{ vendor.institution_id }}</td>
             </tr>
             <tr>
-                <td>Federal Tax ID</td>
+                <td class="label">Federal Tax ID</td>
                 <td>{{ vendor.federal_tax_id }}</td>
             </tr>
             <tr>
-                <td>Vendor Note</td>
+                <td class="label">Vendor Note</td>
                 <td>{{ vendor.vendor_note }}</td>
             </tr>
             <tr>
-                <td>Default Currency</td>
+                <td class="label">Default Currency</td>
                 <td>{{ vendor.default_currency }}</td>
             </tr>
             <tr>
-                <td>Claim Interval</td>
+                <td class="label">Claim Interval</td>
                 <td>{{ vendor.claim_interval }}</td>
             </tr>
             <tr>
-                <td>Claim Count</td>
+                <td class="label">Claim Count</td>
                 <td>{{ vendor.claim_count }}</td>
             </tr>
             <tr>
-                <td>Cancel Interval</td>
+                <td class="label">Cancel Interval</td>
                 <td>{{ vendor.cancel_interval }}</td>
             </tr>
             <tr>
-                <td>Creation Date</td>
+                <td class="label">Creation Date</td>
                 <td>{{ vendor.create_date }}</td>
             </tr>
             <tr>
-                <td>Creation Operator ID</td>
+                <td class="label">Creation Operator ID</td>
                 <td>{{ vendor.create_operator_id }}</td>
             </tr>
             <tr>
-                <td>Modification Date</td>
+                <td class="label">Modification Date</td>
                 <td>{{ vendor.modify_date }}</td>
             </tr>
             <tr>
-                <td>Modification Operator ID</td>
+                <td class="label">Modification Operator ID</td>
                 <td>{{ vendor.modify_operator_id }}</td>
             </tr>
             <tr>
-                <td>Number of Associated Accounts</td>
+                <td class="label">Number of Associated Accounts</td>
                 <td>{{ vendor_accts.count }}</td>
             </tr>
         </table>
@@ -85,31 +85,31 @@
 
     <div class="column">
         {% if vendor_accts %}
-        <h1>Vendor Account Information</h1>
+        <h2>Vendor Account Information</h2>
         {% for acct in vendor_accts %}
         <table class="data-display">
             <tr>
-                <td>Account Name</td>
+                <td class="label">Account Name</td>
                 <td>{{ acct.account_name }}</td>
             </tr>
             <tr>
-                <td>Account Number</td>
+                <td class="label">Account Number</td>
                 <td>{{ acct.account_number }}</td>
             </tr>
             <tr>
-                <td>Vendor Account ID</td>
+                <td class="label">Vendor Account ID</td>
                 <td>{{ acct.vendor_account_id }}</td>
             </tr>
             <tr>
-                <td>Vendor ID</td>
+                <td class="label">Vendor ID</td>
                 <td>{{ acct.vendor_id }}</td>
             </tr>
             <tr>
-                <td>Deposit</td>
+                <td class="label">Deposit</td>
                 <td>{{ acct.deposit }}</td>
             </tr>
             <tr>
-                <td>Default PO Type</td>
+                <td class="label">Default PO Type</td>
                 <td>{{ acct.default_po_type }}</td>
             </tr>
         </table>


### PR DESCRIPTION
Relates to [SYS-1030](https://jira.library.ucla.edu/browse/SYS-1030)

Updates vendor and item templates to use the "label" CSS class on data labels. Additionally, replaces h1s with h2s in these templates to better align with the PO template (and to avoid multiple h1s on a page). 

For testing, vendor codes "LQZ" and "YAGI", and item barcode "L0112367321" are available.