### PR TITLE
SYS-1031: Enable display of MARC suppression

### DIFF
--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -309,6 +309,7 @@ create or replace view auth_record_view as
 select
 	auth_id
 ,	auth_record
+,	'N' as suppressed
 from auth_record
 ;
 

--- a/voyager_archive/models.py
+++ b/voyager_archive/models.py
@@ -2632,18 +2632,34 @@ class PoLineItemView(models.Model):
         db_table = "po_line_item_view"
 
 
-class AuthRecordView(models.Model):
-    auth_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    auth_record = models.TextField(blank=True, null=True)
+class MARCRecordView(models.Model):
+    marc_record_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0
+    )
+    marc_record = models.TextField(blank=True, null=True)
+    suppressed = models.CharField(max_length=1, blank=True, null=True)
+
+    class Meta:
+        abstract = True
+
+
+class AuthRecordView(MARCRecordView):
+    marc_record_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0, db_column="auth_id"
+    )
+    marc_record = models.TextField(blank=True, null=True, db_column="auth_record")
+    suppressed = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
         managed = False  # Created from a view. Don't remove.
         db_table = "auth_record_view"
 
 
-class BibRecordView(models.Model):
-    bib_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    bib_record = models.TextField(blank=True, null=True)
+class BibRecordView(MARCRecordView):
+    marc_record_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0, db_column="bib_id"
+    )
+    marc_record = models.TextField(blank=True, null=True, db_column="bib_record")
     suppressed = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:
@@ -2651,9 +2667,11 @@ class BibRecordView(models.Model):
         db_table = "bib_record_view"
 
 
-class MfhdRecordView(models.Model):
-    mfhd_id = models.DecimalField(primary_key=True, max_digits=38, decimal_places=0)
-    mfhd_record = models.TextField(blank=True, null=True)
+class MfhdRecordView(MARCRecordView):
+    marc_record_id = models.DecimalField(
+        primary_key=True, max_digits=38, decimal_places=0, db_column="mfhd_id"
+    )
+    marc_record = models.TextField(blank=True, null=True, db_column="mfhd_record")
     suppressed = models.CharField(max_length=1, blank=True, null=True)
 
     class Meta:

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -15,8 +15,14 @@
     <div class="column">
         <table class="data-display">
             {% comment %}
-            Leader is special; display before regular fields.
+            Leader and suppression info are special;
+            display before regular fields.
             {% endcomment %}
+            <tr>
+                <td>Suppressed</td>
+                <td></td>
+                <td>{{ marc_record.suppressed }}</td>
+            </tr>
             <tr>
                 <td>LDR</td>
                 <td></td>


### PR DESCRIPTION
Implements [SYS-1031](https://jira.library.ucla.edu/browse/SYS-1031).

This PR adds a row showing "Suppression" with Y/N value at the start of the MARC record display, for all MARC record types:
![marc_suppression](https://user-images.githubusercontent.com/2213836/196833678-41435c64-e107-485f-b89a-e7e06ec6ca4a.png)

There are some significant changes behind the scenes, as the necessary data wasn't being passed to the Django view, and doing it consistently required the following:
* Modifying the Django `*RecordView` models to inherit from a new abstract model, `MARCRecordView`
* Renaming fields in these Django models to be consistent (`marc_record_id` instead of `auth_id` or `bib_id`, for example) while preserving the specific column names in the underlying database views
* Adding `suppressed` column to `auth_record_view` database view; authority records aren't (can't be) suppressed, so this is a constant `N`
* Updating and improving parameters and type hints in the relevant methods in `views_utils.py`
* Changing some variable names to reduce confusion (I hope...)
* Adding comments to further reduce confusion / clarify MARC processing code
* Finally... add the now-consistently-available `suppressed` value to the dictionary which is passed to the template for display

I considered adding tests for these changes, but our non-`Managed` models means we can't create normal fixtures, which are required for database-backed testing.

