### PR TITLE
Sys 1016/voyager helm chart

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,26 @@
+# Helm Ignore
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Environment-specific Values files
+/voyagerarchive-values.yaml

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.1"
+description: Chart for Voyager Archive Django applications
+name: voyagerarchive
+version: 0.1.0

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "lbs.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "lbs.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "lbs.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "lbs.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "voyagerarchive.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "voyagerarchive.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "voyagerarchive.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "voyagerarchive.labels" -}}
+helm.sh/chart: {{ include "voyagerarchive.chart" . }}
+{{ include "voyagerarchive.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "voyagerarchive.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "voyagerarchive.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-configmap
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "voyagerarchive.labels" . | nindent 4 }}
+data:
+  DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
+  DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}
+  DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
+  DJANGO_DB_USER: {{ .Values.django.env.db_user }}
+  DJANGO_DB_HOST: {{ .Values.django.env.db_host }}
+  DJANGO_DB_PORT: {{ .Values.django.env.db_port | quote }}
+  DJANGO_TEST_DB_NAME: {{ .Values.django.env.test_db_name }}
+  DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+  DJANGO_EMAIL_SMTP_SERVER: {{ .Values.django.env.email_smtp_server }}
+  DJANGO_EMAIL_SMTP_PORT: {{ .Values.django.env.email_smtp_port | quote }}
+  DJANGO_EMAIL_FROM_ADDRESS: {{ .Values.django.env.email_from_address }}
+  DJANGO_EMAIL_PASSWORD: {{ .Values.django.env.email_password }}
+  
+  # voyager archive database server
+  VA_DB_SERVER: {{ .Values.django.env.va_db_server }}
+  VA_DB_USER: {{ .Values.django.env.va_db_user }}
+  VA_DB_DATABASE: {{ .Values.django.env.va_db_database }}
+  

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lbs.fullname" . }}
+  namespace: lbs{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "lbs.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lbs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lbs.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "lbs.fullname" . }}-configmap
+            - secretRef:
+                name: {{ include "lbs.fullname" . }}-secrets
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /login/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          readinessProbe:
+            httpGet:
+              path: /login/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-externalsecrets
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  refreshInterval: 10m
+  secretStoreRef:
+    name: systems-clustersecretstore
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "voyagerarchive.fullname" . }}-secrets
+  data:
+  - secretKey: "DJANGO_SECRET_KEY"
+    remoteRef:
+      key: {{ .Values.django.externalSecrets.env.django_secret_key }}
+  - secretKey: "DJANGO_DB_PASSWORD"
+    remoteRef:
+      key: {{ .Values.django.externalSecrets.env.db_password }}
+  - secretKey: "VA_UCLA_DB_PASSWORD"
+    remoteRef:
+      key: {{ .Values.django.externalSecrets.env.va_ucla_db_password }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "lbs.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: lbs{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "lbs.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+     {{- end }}
+{{- end }}

--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lbs{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-secrets
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  labels:
+{{ include "voyagerarchive.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  VA_UCLA_ETHNO_PASSWORD: {{ .Values.django.env.va_ethno_db_password | b64enc | quote }}
+  VA_UCLA_FTA_PASSWORD: {{ .Values.django.env.va_fta_db_password | b64enc | quote }}
+  VA_UCLA_DB_PASSWORD: {{ .Values.django.env.va_ucla_db_password | b64enc | quote }}
+{{ end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lbs.fullname" . }}
+  namespace: lbs{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "lbs.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.django.env.target_port | default "8000" }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lbs.selectorLabels" . | nindent 4 }}

--- a/charts/templates/va-ethno-secrets.yaml
+++ b/charts/templates/va-ethno-secrets.yaml
@@ -1,0 +1,16 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-secrets
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  labels:
+{{ include "voyagerarchive.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  VA_UCLA_ETHNO_PASSWORD: {{ .Values.django.env.va_ethno_db_password | b64enc | quote }}
+  VA_UCLA_FTA_PASSWORD: {{ .Values.django.env.va_fta_db_password | b64enc | quote }}
+  VA_UCLA_DB_PASSWORD: {{ .Values.django.env.va_ucla_db_password | b64enc | quote }}
+{{ end }}

--- a/charts/templates/va-fta-secrets.yaml
+++ b/charts/templates/va-fta-secrets.yaml
@@ -1,0 +1,16 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-secrets
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  labels:
+{{ include "voyagerarchive.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  VA_UCLA_ETHNO_PASSWORD: {{ .Values.django.env.va_ethno_db_password | b64enc | quote }}
+  VA_UCLA_FTA_PASSWORD: {{ .Values.django.env.va_fta_db_password | b64enc | quote }}
+  VA_UCLA_DB_PASSWORD: {{ .Values.django.env.va_ucla_db_password | b64enc | quote }}
+{{ end }}

--- a/charts/templates/va-ucla-secrets.yaml
+++ b/charts/templates/va-ucla-secrets.yaml
@@ -1,0 +1,16 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "voyagerarchive.fullname" . }}-secrets
+  namespace: voyagerarchive{{ .Values.django.env.run_env }}
+  labels:
+{{ include "voyagerarchive.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  VA_UCLA_ETHNO_PASSWORD: {{ .Values.django.env.va_ethno_db_password | b64enc | quote }}
+  VA_UCLA_FTA_PASSWORD: {{ .Values.django.env.va_fta_db_password | b64enc | quote }}
+  VA_UCLA_DB_PASSWORD: {{ .Values.django.env.va_ucla_db_password | b64enc | quote }}
+{{ end }}

--- a/charts/va-ethno-values.yaml
+++ b/charts/va-ethno-values.yaml
@@ -1,0 +1,86 @@
+# Values for voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  tag: 1.0.1
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'va-ucla.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: lbs-tls
+    hosts:
+      - va-ucla.library.ucla.edu
+
+django:
+  env:
+    run_env: "test"
+    debug: "false"
+    allowed_hosts:
+      - lbs.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "qdb"
+    db_user: "qdb"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    test_db_name: "qdb"
+    email_backend: "django.core.mail.backends.smtp.EmailBackend"
+    email_smtp_server: "smtp.ucla.edu"
+    # UCLA smtp uses no authentication nor TLS
+    email_smtp_port: 25
+    email_from_address: "akohler@library.ucla.edu"
+    email_password: "fake_value"
+    
+    # app_ip doesn't seem mandatory, but the legacy QDB app uses it
+    # This is the IP address / domain name that is passed to the SMTP server as the sender's machine.
+    app_ip: "lbs.library.ucla.edu"
+    # QDB database server
+    qdb_db_server: "obiwan.qdb.ucla.edu"
+    qdb_db_database: "qdb"
+    qdb_db_user: "mgrlib"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/testsoftwaredev/lbstest/db_password"
+      django_secret_key: "/systems/testsoftwaredev/lbstest/django_secret_key"
+      # UCLA QDB database, from which data is pulled for reports
+      qdb_db_password: "/systems/testsoftwaredev/lbstest/qdb_db_password"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/va-fta-values.yaml
+++ b/charts/va-fta-values.yaml
@@ -1,0 +1,86 @@
+# Values for voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  tag: 1.0.1
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'va-ucla.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: lbs-tls
+    hosts:
+      - va-ucla.library.ucla.edu
+
+django:
+  env:
+    run_env: "test"
+    debug: "false"
+    allowed_hosts:
+      - lbs.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "qdb"
+    db_user: "qdb"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    test_db_name: "qdb"
+    email_backend: "django.core.mail.backends.smtp.EmailBackend"
+    email_smtp_server: "smtp.ucla.edu"
+    # UCLA smtp uses no authentication nor TLS
+    email_smtp_port: 25
+    email_from_address: "akohler@library.ucla.edu"
+    email_password: "fake_value"
+    
+    # app_ip doesn't seem mandatory, but the legacy QDB app uses it
+    # This is the IP address / domain name that is passed to the SMTP server as the sender's machine.
+    app_ip: "lbs.library.ucla.edu"
+    # QDB database server
+    qdb_db_server: "obiwan.qdb.ucla.edu"
+    qdb_db_database: "qdb"
+    qdb_db_user: "mgrlib"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/testsoftwaredev/lbstest/db_password"
+      django_secret_key: "/systems/testsoftwaredev/lbstest/django_secret_key"
+      # UCLA QDB database, from which data is pulled for reports
+      qdb_db_password: "/systems/testsoftwaredev/lbstest/qdb_db_password"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/va-ucla-values.yaml
+++ b/charts/va-ucla-values.yaml
@@ -1,0 +1,86 @@
+# Values for voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  tag: 1.0.1
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'va-ucla.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: lbs-tls
+    hosts:
+      - va-ucla.library.ucla.edu
+
+django:
+  env:
+    run_env: "test"
+    debug: "false"
+    allowed_hosts:
+      - lbs.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "qdb"
+    db_user: "qdb"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    test_db_name: "qdb"
+    email_backend: "django.core.mail.backends.smtp.EmailBackend"
+    email_smtp_server: "smtp.ucla.edu"
+    # UCLA smtp uses no authentication nor TLS
+    email_smtp_port: 25
+    email_from_address: "akohler@library.ucla.edu"
+    email_password: "fake_value"
+    
+    # app_ip doesn't seem mandatory, but the legacy QDB app uses it
+    # This is the IP address / domain name that is passed to the SMTP server as the sender's machine.
+    app_ip: "lbs.library.ucla.edu"
+    # QDB database server
+    qdb_db_server: "obiwan.qdb.ucla.edu"
+    qdb_db_database: "qdb"
+    qdb_db_user: "mgrlib"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/testsoftwaredev/lbstest/db_password"
+      django_secret_key: "/systems/testsoftwaredev/lbstest/django_secret_key"
+      # UCLA QDB database, from which data is pulled for reports
+      qdb_db_password: "/systems/testsoftwaredev/lbstest/qdb_db_password"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,92 @@
+# Default values for voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts: []
+    #  - localhost
+    #  - 127.0.0.1
+    #  - [::1]
+    db_backend: ""
+    db_name: ""
+    db_user: ""
+    db_host: ""
+    db_port: ""
+    # Include if externalSecrets enabled: "false"
+    #db_password: ""
+    test_db_name: ""
+    email_backend: ""
+    email_smtp_server: ""
+    email_smtp_port: ""
+    email_from_address: ""
+    email_password: ""
+    app_ip: ""
+    target_port: ""
+    
+    # voyager archive database server common values
+    va_db_user: ""
+
+    # voyager archive database server specific values 
+    va_ethno_db_server: ""
+    va_fta_db_server: ""
+    va_ucla_db_server: ""
+
+  externalSecrets:
+    enabled: "false"
+    env: {}
+    # Include below if enabled: "true"
+    #  db_password: ""
+    #  django_secret_key: ""
+    #  va_ethno_db_password: ""
+    #  va_fta_db_password: ""
+    #  va_ucla_db_password: ""
+  
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+

--- a/charts/voyagerarchive-values.yaml
+++ b/charts/voyagerarchive-values.yaml
@@ -1,0 +1,86 @@
+# Values for voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  tag: 1.0.1
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'va-ucla.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: lbs-tls
+    hosts:
+      - va-ucla.library.ucla.edu
+
+django:
+  env:
+    run_env: "test"
+    debug: "false"
+    allowed_hosts:
+      - lbs.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "qdb"
+    db_user: "qdb"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    test_db_name: "qdb"
+    email_backend: "django.core.mail.backends.smtp.EmailBackend"
+    email_smtp_server: "smtp.ucla.edu"
+    # UCLA smtp uses no authentication nor TLS
+    email_smtp_port: 25
+    email_from_address: "akohler@library.ucla.edu"
+    email_password: "fake_value"
+    
+    # app_ip doesn't seem mandatory, but the legacy QDB app uses it
+    # This is the IP address / domain name that is passed to the SMTP server as the sender's machine.
+    app_ip: "lbs.library.ucla.edu"
+    # QDB database server
+    qdb_db_server: "obiwan.qdb.ucla.edu"
+    qdb_db_database: "qdb"
+    qdb_db_user: "mgrlib"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/testsoftwaredev/lbstest/db_password"
+      django_secret_key: "/systems/testsoftwaredev/lbstest/django_secret_key"
+      # UCLA QDB database, from which data is pulled for reports
+      qdb_db_password: "/systems/testsoftwaredev/lbstest/qdb_db_password"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This needs a lot of work but hopefully a better starting point than blank files.
Some initial questions:
* Values and secrets file structure for each environment. Currently, I have a single file, and a file for each environment. We could go with one or the other, a single file with all envs, or separate file for each env. In discussions it sounded like separate file for each env which you then deploy specific values file on command line
* Hostname(s) - I had been using va-{ucla, ethno, fta} for the environments but there are still remnants of voyagerarchive.library.ucla.edu
* lbs references - I used LBS charts as starting point, which may or may not have been wise so still some settings specific to LBS that don't make sense in this context (test environments, dbs, etc...)

I'm still editing, reading docs, and committing locally, so please consider this PR a work in progress 