### PR TITLE
SYS-1016: Initial Helm chart

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -23,5 +23,6 @@
 .vscode/
 
 # Environment-specific Values files
-/test-catalogingstatistics-values.yaml
-/prod-catalogingstatistics-values.yaml
+/prod-ethnovoyagerarchive-values.yaml
+/prod-ftvavoyagerarchive-values.yaml
+/prod-uclavoyagerarchive-values.yaml

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Environment-specific Values files
+/test-catalogingstatistics-values.yaml
+/prod-catalogingstatistics-values.yaml

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.1"
+description: Chart for Cataloging Statistics application
+name: cataloging-statistics
+version: 0.0.2

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 appVersion: "0.1"
-description: Chart for Cataloging Statistics application
-name: cataloging-statistics
-version: 0.0.2
+description: Chart for Voyager Archive application
+name: voyager-archive
+version: 0.0.1

--- a/charts/prod-ethnovoyagerarchive-values.yml
+++ b/charts/prod-ethnovoyagerarchive-values.yml
@@ -22,8 +22,8 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/prod-ethnovoyagerarchive-values.yml
+++ b/charts/prod-ethnovoyagerarchive-values.yml
@@ -1,0 +1,73 @@
+# Values for ethno voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  # tag: v0.0.1
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'ethno-voy-archive.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: ethno-voyager-archive-tls
+    hosts:
+      - ethno-voy-archive.library.ucla.edu
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts:
+      - ethno-voy-archive.library.ucla.edu
+    csrf_trusted_origins:
+      - https://ethno-voy-archive.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "ucla_voy_archive"
+    db_user: "voy_archive_access"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    log_level: "INFO"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/prodsoftwaredev/voyager-archive/db_password"
+      django_secret_key: "/systems/prodsoftwaredev/voyager-archive/django_secret_key"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/prod-ethnovoyagerarchive-values.yml
+++ b/charts/prod-ethnovoyagerarchive-values.yml
@@ -22,8 +22,6 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/prod-ftvavoyagerarchive-values.yml
+++ b/charts/prod-ftvavoyagerarchive-values.yml
@@ -22,8 +22,8 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/prod-ftvavoyagerarchive-values.yml
+++ b/charts/prod-ftvavoyagerarchive-values.yml
@@ -1,0 +1,73 @@
+# Values for ftva voyager-archive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/voyager-archive
+  # tag: v0.0.1
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'ftva-voy-archive.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: ftva-voyager-archive-tls
+    hosts:
+      - ftva-voy-archive.library.ucla.edu
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts:
+      - ftva-voy-archive.library.ucla.edu
+    csrf_trusted_origins:
+      - https://ftva-voy-archive.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "ucla_voy_archive"
+    db_user: "voy_archive_access"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    log_level: "INFO"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/prodsoftwaredev/voyager-archive/db_password"
+      django_secret_key: "/systems/prodsoftwaredev/voyager-archive/django_secret_key"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/prod-ftvavoyagerarchive-values.yml
+++ b/charts/prod-ftvavoyagerarchive-values.yml
@@ -22,8 +22,6 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -22,8 +22,8 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -1,12 +1,13 @@
-# Values for cataloging-statisticstest.
+# Values for ucla voyager-archive.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
 
 image:
-  repository: uclalibrary/cataloging-statistics
-  tag: v0.9.8
+  repository: uclalibrary/voyager-archive
+  # tag: v0.0.1
+  tag: latest
   pullPolicy: Always
 
 nameOverride: ""
@@ -27,25 +28,25 @@ ingress:
     kubernetes.io/tls-acme: "true"
 
   hosts:
-    - host: 'catstats.library.ucla.edu'
+    - host: 'ucla-voy-archive.library.ucla.edu'
       paths:
         - "/"
   tls:
-  - secretName: cataloging-statistics-tls
+  - secretName: ucla-voyager-archive-tls
     hosts:
-      - catstats.library.ucla.edu
+      - ucla-voy-archive.library.ucla.edu
 
 django:
   env:
-    run_env: "test"
+    run_env: "prod"
     debug: "false"
     allowed_hosts:
-      - catstats.library.ucla.edu
+      - ucla-voy-archive.library.ucla.edu
     csrf_trusted_origins:
-      - https://catstats.library.ucla.edu
+      - https://ucla-voy-archive.library.ucla.edu
     db_backend: "django.db.backends.postgresql_psycopg2"
-    db_name: "cataloging_stats"
-    db_user: "cataloging_stats"
+    db_name: "ucla_voy_archive"
+    db_user: "voy_archive_access"
     db_host: "p-d-postgres.library.ucla.edu"
     db_port: 5432
     log_level: "INFO"
@@ -54,9 +55,8 @@ django:
     enabled: "true"
     env:
       # Application database used by django
-      db_password: "/systems/testsoftwaredev/cataloging-statisticstest/db_password"
-      django_secret_key: "/systems/testsoftwaredev/cataloging-statisticstest/django_secret_key"
-      alma_api_key: "/systems/testsoftwaredev/cataloging-statisticstest/alma_api_key"
+      db_password: "/systems/prodsoftwaredev/voyager-archive/db_password"
+      django_secret_key: "/systems/prodsoftwaredev/voyager-archive/django_secret_key"
 
 resources:
   limits:

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -22,8 +22,6 @@ ingress:
   enabled: "true"
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
 

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cataloging-statistics.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cataloging-statistics.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cataloging-statistics.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cataloging-statistics.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cataloging-statistics.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "voyager-archive.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cataloging-statistics.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cataloging-statistics.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "voyager-archive.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "voyager-archive.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cataloging-statistics.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "voyager-archive.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cataloging-statistics.name" -}}
+{{- define "voyager-archive.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "cataloging-statistics.fullname" -}}
+{{- define "voyager-archive.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cataloging-statistics.chart" -}}
+{{- define "voyager-archive.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "cataloging-statistics.labels" -}}
-helm.sh/chart: {{ include "cataloging-statistics.chart" . }}
-{{ include "cataloging-statistics.selectorLabels" . }}
+{{- define "voyager-archive.labels" -}}
+helm.sh/chart: {{ include "voyager-archive.chart" . }}
+{{ include "voyager-archive.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,8 +45,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "cataloging-statistics.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "cataloging-statistics.name" . }}
+{{- define "voyager-archive.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "voyager-archive.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cataloging-statistics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cataloging-statistics.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cataloging-statistics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cataloging-statistics.labels" -}}
+helm.sh/chart: {{ include "cataloging-statistics.chart" . }}
+{{ include "cataloging-statistics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cataloging-statistics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cataloging-statistics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cataloging-statistics.fullname" . }}-configmap
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: {{ include "voyager-archive.fullname" . }}-configmap
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   labels:
-    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+    {{- include "voyager-archive.labels" . | nindent 4 }}
 data:
   DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
   DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-configmap
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+data:
+  DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
+  DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_CSRF_TRUSTED_ORIGINS: {{ range .Values.django.env.csrf_trusted_origins }}{{ . | quote }}{{ end }}
+  DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}
+  DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
+  DJANGO_DB_USER: {{ .Values.django.env.db_user }}
+  DJANGO_DB_HOST: {{ .Values.django.env.db_host }}
+  DJANGO_DB_PORT: {{ .Values.django.env.db_port | quote }}
+  DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}
+

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cataloging-statistics.fullname" . }}
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: {{ include "voyager-archive.fullname" . }}
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   labels:
-    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+    {{- include "voyager-archive.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "cataloging-statistics.selectorLabels" . | nindent 6 }}
+      {{- include "voyager-archive.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "cataloging-statistics.selectorLabels" . | nindent 8 }}
+        {{- include "voyager-archive.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -21,23 +21,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ include "cataloging-statistics.fullname" . }}-configmap
+                name: {{ include "voyager-archive.fullname" . }}-configmap
             - secretRef:
-                name: {{ include "cataloging-statistics.fullname" . }}-secrets
+                name: {{ include "voyager-archive.fullname" . }}-secrets
           ports:
             - name: http
               containerPort: 8000
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /report
+              path: /
               port: http
               httpHeaders:
                 - name: Host
                   value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
           readinessProbe:
             httpGet:
-              path: /report
+              path: /
               port: http
               httpHeaders:
                 - name: Host

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cataloging-statistics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cataloging-statistics.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "cataloging-statistics.fullname" . }}-configmap
+            - secretRef:
+                name: {{ include "cataloging-statistics.fullname" . }}-secrets
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /report
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          readinessProbe:
+            httpGet:
+              path: /report
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,8 +1,8 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "cataloging-statistics.fullname" . }}-externalsecret
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: {{ include "voyager-archive.fullname" . }}-externalsecret
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -12,7 +12,7 @@ spec:
     name: systems-clustersecretstore
     kind: ClusterSecretStore
   target:
-    name: {{ include "cataloging-statistics.fullname" . }}-secrets
+    name: {{ include "voyager-archive.fullname" . }}-secrets
   data:
     - secretKey: "DJANGO_SECRET_KEY"
       remoteRef:
@@ -20,6 +20,3 @@ spec:
     - secretKey: "DJANGO_DB_PASSWORD"
       remoteRef:
         key: {{ .Values.django.externalSecrets.env.db_password }}
-    - secretKey: "ALMA_API_KEY"
-      remoteRef:
-        key: {{ .Values.django.externalSecrets.env.alma_api_key }}

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.django.externalSecrets.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -20,3 +21,4 @@ spec:
     - secretKey: "DJANGO_DB_PASSWORD"
       remoteRef:
         key: {{ .Values.django.externalSecrets.env.db_password }}
+{{ end }}

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-externalsecret
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  refreshInterval: 10m
+  secretStoreRef:
+    name: systems-clustersecretstore
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "cataloging-statistics.fullname" . }}-secrets
+  data:
+    - secretKey: "DJANGO_SECRET_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.django_secret_key }}
+    - secretKey: "DJANGO_DB_PASSWORD"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.db_password }}
+    - secretKey: "ALMA_API_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.alma_api_key }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "cataloging-statistics.fullname" . -}}
+{{- $fullName := include "voyager-archive.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   labels:
-    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+    {{- include "voyager-archive.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cataloging-statistics.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+     {{- end }}
+{{- end }}

--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cataloging-statistics{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed

--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: voyager-archive{{ .Values.django.env.run_env }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-failed

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cataloging-statistics.fullname" . }}-secrets
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: {{ include "voyager-archive.fullname" . }}-secrets
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   labels:
-{{ include "cataloging-statistics.fullname" . | indent 4 }}
+{{ include "voyager-archive.fullname" . | indent 4 }}
 type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-secrets
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+{{ include "cataloging-statistics.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  ALMA_API_KEY: {{ .Values.django.env.alma_api_key | b64enc | quote }}
+{{ end }}

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -10,5 +10,4 @@ type: Opaque
 data:
   DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
   DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
-  ALMA_API_KEY: {{ .Values.django.env.alma_api_key | b64enc | quote }}
 {{ end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cataloging-statistics.fullname" . }}
-  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  name: {{ include "voyager-archive.fullname" . }}
+  namespace: voyager-archive{{ .Values.django.env.run_env }}
   labels:
-    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+    {{- include "voyager-archive.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "cataloging-statistics.selectorLabels" . | nindent 4 }}
+    {{- include "voyager-archive.selectorLabels" . | nindent 4 }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.django.env.target_port | default "8000" }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cataloging-statistics.selectorLabels" . | nindent 4 }}

--- a/charts/test-catalogingstatistics-values.yaml
+++ b/charts/test-catalogingstatistics-values.yaml
@@ -1,0 +1,73 @@
+# Values for cataloging-statisticstest.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/cataloging-statistics
+  tag: v0.9.8
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+  
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+
+  hosts:
+    - host: 'catstats.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: cataloging-statistics-tls
+    hosts:
+      - catstats.library.ucla.edu
+
+django:
+  env:
+    run_env: "test"
+    debug: "false"
+    allowed_hosts:
+      - catstats.library.ucla.edu
+    csrf_trusted_origins:
+      - https://catstats.library.ucla.edu
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_name: "cataloging_stats"
+    db_user: "cataloging_stats"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    log_level: "INFO"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/testsoftwaredev/cataloging-statisticstest/db_password"
+      django_secret_key: "/systems/testsoftwaredev/cataloging-statisticstest/django_secret_key"
+      alma_api_key: "/systems/testsoftwaredev/cataloging-statisticstest/alma_api_key"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 500Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,75 @@
+# Default values for cataloging-statistics.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/cataloging-statistics
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts: []
+    #  - localhost
+    #  - 127.0.0.1
+    #  - [::1]
+    csrf_trusted_origins: []
+    db_backend: ""
+    db_name: ""
+    db_user: ""
+    db_host: ""
+    db_port: ""
+    # Include if externalSecrets enabled: "false"
+    #db_password: ""
+    log_level: ""
+
+  externalSecrets:
+    enabled: "false"
+    env: {}
+    # Include below if enabled: "true"
+    #  db_password: ""
+    #  django_secret_key: ""
+  
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,11 +1,11 @@
-# Default values for cataloging-statistics.
+# Default values for voyager-archive.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
 
 image:
-  repository: uclalibrary/cataloging-statistics
+  repository: uclalibrary/voyager-archive
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
Implements [SYS-1016](https://jira.library.ucla.edu/browse/SYS-1035)

This PR adds the initial version of the Helm chart for the Voyager Archive application.  It includes 3 specific values files, one for each instance of the VA (ethno, ftva, and ucla).

Questions / comments:
* Are the specific values files named correctly?  `prod-ethnovoyagerarchive-values.yaml` etc.
* Are the `tls -> secretName` values correct?  `ethno-voyager-archive-tls` etc.
* There are only 2 real secrets, which are shared across the 3 application instances.
* Secrets have been created in AWS
