### PR TITLE
SYS-1037: Show links to all 3 archives on every page

### DIFF
--- a/voyager_archive/templates/voyager_archive/base.html
+++ b/voyager_archive/templates/voyager_archive/base.html
@@ -5,6 +5,11 @@
         <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
     </head>
     <body>
+        <p class="label">Archives:
+            <a href="https://ethno-voy-archive.library.ucla.edu/">Ethno</a> / 
+            <a href="https://ftva-voy-archive.library.ucla.edu/">FTVA</a> / 
+            <a href="https://ucla-voy-archive.library.ucla.edu/">UCLA</a>
+        </p>
         {% block content %}
         {% endblock %}
     </body>


### PR DESCRIPTION
Implements [SYS-1037](https://jira.library.ucla.edu/browse/SYS-1037).

This PR updates the base template with links to all 3 Voyager Archive sites.  The links, which go to the root search page, then appear on every page in the application.

The links don't currently work, as they are for the real domains, which exist but are not yet running.

I leveraged the `label` CSS class, on a `p` element instead of `div`... so feel free to request changes if there's a better way to do this, while keeping a compact one-line display.

Sample screenshot:
![domain_links](https://user-images.githubusercontent.com/2213836/197657861-90d7da41-97cc-482f-91d1-0746a2571b54.png)

