### PR TITLE
SYS-1039: Fix display of line items on main PO template

### DIFF
--- a/sql_support/sample_data.sql
+++ b/sql_support/sample_data.sql
@@ -488,6 +488,8 @@ SET synchronous_commit TO off;
 
 COPY line_item_funds (copy_id,split_fund_seq,ledger_id,fund_id,percentage,prepay_percentage,amount,prepay,allocation_method) FROM STDIN;
 1159093	1	326	3777	100000000	100000000	0	0	P
+1159091	1	326	3777	100000000	100000000	0	0	P
+1159094	1	326	3777	100000000	100000000	0	0	P
 128592	1	355	6758	100000000	0	0	0	P
 1185415	1	336	4717	100000000	100000000	4400	0	P
 \.
@@ -648,4 +650,3 @@ COPY fund (fund_id,ledger_id,parent_fund,fund_name,normal_fund_name,fund_code,no
 \.
 
 COMMIT;
-

--- a/voyager_archive/templates/voyager_archive/po_display.html
+++ b/voyager_archive/templates/voyager_archive/po_display.html
@@ -97,11 +97,10 @@
     </div>
 </div>
 
+{% if po_lines %}
 <div class="row">
     <div class="column">
-        {% if po_lines %}
         <h2>Purchase Order Lines</h2>
-        {% for line in po_lines %}
         <table class="data-display">
             <tr>
                 <th>Line #</th>
@@ -110,6 +109,7 @@
                 <th>Piece Identifier</th>
                 <th>Amount</th>
             </tr>
+        {% for line in po_lines %}
             <tr>
                 <td class="label">
                     #{{ line.line_item_number }} <a href="{% url 'po_line_display' line.line_item_id %}">(details)</a>
@@ -119,16 +119,10 @@
                 <td>{% if line.piece_identifer %}{{ line.piece_identifier }}{% endif %}</td>
                 <td>USD ${{ line.usd_amount|floatformat:2 }}</td>
             </tr>
-            {% comment %}
-            <tr>
-                <td class="label"></td>
-                <td></td>
-            </tr>
-            {% endcomment %}
-        </table>
         {% endfor %}
-        {% endif %}
+        </table>
     </div>
 </div>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Implements [SYS-1039](https://jira.library.ucla.edu/browse/SYS-1039).

This PR fixes a bug in the `po_display.html` template, which incorrectly displayed brief data for each PO line in its own table.  With this fix, the lines now all display in one table, so alignment and row shading are correct.

Screenshot, via search for PO `EAL518017`:
![EAL518017_po_lines_fixed](https://user-images.githubusercontent.com/2213836/197660357-481fc273-0c09-4406-a7cb-8c6948425b86.png)

Ignore the missing line `#2`, I only added enough new sample data to demonstrate that this is now fixed.