### PR TITLE
SYS-1036: Display invoice line details

### DIFF
--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -168,6 +168,9 @@ select
 ,	ili.inv_line_item_id
 ,	ili.line_item_id
 ,	ilif.copy_id
+,	i.invoice_number
+,	po.po_id
+,	po.po_number
 ,	li.bib_id
 ,	bt.title
 ,	lis.line_item_status_desc as status
@@ -191,8 +194,10 @@ from invoice_line_item ili
 inner join invoice_line_item_funds ilif on ili.inv_line_item_id = ilif.inv_line_item_id
 inner join fund f on ilif.ledger_id = f.ledger_id and ilif.fund_id = f.fund_id
 inner join ledger l on f.ledger_id = l.ledger_id
+inner join invoice i on ili.invoice_id = i.invoice_id
 inner join line_item li on ili.line_item_id = li.line_item_id
 inner join bib_title bt on li.bib_id = bt.bib_id
+inner join purchase_order po on li.po_id = po.po_id
 inner join line_item_copy_status lics on ili.line_item_id = lics.line_item_id
 inner join line_item_status lis on lics.line_item_status = lis.line_item_status
 ;

--- a/voyager_archive/models.py
+++ b/voyager_archive/models.py
@@ -2486,6 +2486,9 @@ class InvoiceLineView(models.Model):
     copy_id = models.DecimalField(
         max_digits=38, decimal_places=0, blank=True, null=True
     )
+    invoice_number = models.CharField(max_length=25, blank=True, null=True)
+    po_id = models.DecimalField(max_digits=38, decimal_places=0, blank=True, null=True)
+    po_number = models.CharField(max_length=25, blank=True, null=True)
     unit_price = models.DecimalField(
         max_digits=65535, decimal_places=65535, blank=True, null=True
     )

--- a/voyager_archive/templates/voyager_archive/invoice_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_display.html
@@ -108,6 +108,7 @@
         <h2>Invoice Lines</h2>
         <table class="data-display">
             <tr>
+                <th>Line #</th>
                 <th>Status</th>
                 <th>Title</th>
                 <th>Piece Identifier</th>
@@ -116,6 +117,8 @@
             </tr>
         {% for line in inv_lines %}
             <tr>
+                {% comment %}No real invoice line numbers, so use loop counter (1-based){% endcomment %}
+                <td>#{{ forloop.counter }} <a href="{% url 'inv_line_display' line.inv_line_item_id %}">(details)</a></td>
                 <td>{{ line.status }}</td>
                 <td>{{ line.bib_id }} {{ line.title }}</td>
                 <td>{% if line.piece_identifier %}{{line.piece_identifier }}{% endif %}</td>

--- a/voyager_archive/templates/voyager_archive/invoice_line_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_line_display.html
@@ -1,0 +1,130 @@
+{% extends 'voyager_archive/base.html' %}
+{% block content %}
+
+{% for line in inv_lines %}
+<div class="row">
+    <div class="column">
+        <h2>Invoice Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Invoice Number</td>
+                <td>{{ line.invoice_number }}</td>
+            </tr>
+            <tr>
+                <td class="label">PO Number</td>
+                <td>{{ line.po_number }}</td>
+            </tr>
+            <tr>
+                <td class="label">Invoice ID</td>
+                <td>{{ line.invoice_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Invoice Line Item ID</td>
+                <td>{{ line.inv_line_item_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Line Item ID</td>
+                <td>{{ line.line_item_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Copy ID</td>
+                <td>{{ line.copy_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">PO ID</td>
+                <td>{{ line.po_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Status</td>
+                <td>{{ line.status }}</td>
+            </tr>
+        </table>
+        <h2>Metadata Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Creation Date</td>
+                <td>{{ line.create_date }}</td>
+            </tr>
+            <tr>
+                <td class="label">Creation Operator ID</td>
+                <td>{{ line.create_operator_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Modification Date</td>
+                <td>{{ line.modify_date }}</td>
+            </tr>
+            <tr>
+                <td class="label">Modification Operator ID</td>
+                <td>{{ line.modify_operator_id }}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="column">
+        <h2>Item Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Bib ID</td>
+                <td>{{ line.bib_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Title</td>
+                <td>{{ line.title }}</td>
+            </tr>
+            <tr>
+                <td class="label">Piece Identifier</td>
+                <td>{{ line.piece_identifier }}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="column">
+        <h2>Fund and Price Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Unit Price</td>
+                <td>{{ line.unit_price|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Line Price</td>
+                <td>{{ line.line_price|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Split Fund Sequence #</td>
+                <td>{{ line.split_fund_seq }}</td>
+            </tr>
+            <tr>
+                <td class="label">Percentage</td>
+                <td>{{ line.percentage }}</td>
+            </tr>
+            <tr>
+                <td class="label">USD Amount</td>
+                <td>{{ line.usd_amount|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Quantity</td>
+                <td>{{ line.quantity }}</td>
+            </tr>
+            <tr>
+                <td class="label">Ledger Name</td>
+                <td>{{ line.ledger_name }}</td>
+            </tr>
+            <tr>
+                <td class="label">Fund Name</td>
+                <td>{{ line.fund_name }}</td>
+            </tr>
+            <tr>
+                <td class="label">Fund Code</td>
+                <td>{{ line.fund_code }}</td>
+            </tr>
+            <tr>
+                <td class="label">FAU</td>
+                <td>{{ line.fau }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+{% if not forloop.last %}
+<hr>
+{% endif %}
+{% endfor %}
+
+{% endblock %}

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -9,6 +9,11 @@ urlpatterns = [
         name="po_line_display",
     ),
     path(
+        "inv_line_display/<int:inv_line_item_id>",
+        views.inv_line_display,
+        name="inv_line_display",
+    ),
+    path(
         "marc_display/<str:marc_type>/<int:record_id>",
         views.marc_display,
         name="marc_display",

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -1,3 +1,4 @@
+from curses.ascii import HT
 from http.client import INTERNAL_SERVER_ERROR
 import logging
 from django.shortcuts import render
@@ -89,3 +90,9 @@ def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
         "marc_record": marc_record,
     }
     return render(request, "voyager_archive/marc_display.html", context)
+
+
+def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> None:
+    inv_lines = get_inv_lines_by_line_id(inv_line_item_id)
+    context = {"inv_lines": inv_lines}
+    return render(request, "voyager_archive/invoice_line_display.html", context)

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -125,6 +125,13 @@ def get_inv_lines(invoice_id: int) -> QuerySet:
     return inv_lines
 
 
+def get_inv_lines_by_line_id(inv_line_item_id: int) -> QuerySet:
+    inv_lines = InvoiceLineView.objects.filter(
+        inv_line_item_id=inv_line_item_id
+    ).order_by("split_fund_seq")
+    return inv_lines
+
+
 def get_inv_adjustments(invoice_id: int) -> QuerySet:
     inv_adjustments = InvoiceAdjustmentView.objects.filter(
         invoice_id=invoice_id


### PR DESCRIPTION
Implements [SYS-1036](https://jira.library.ucla.edu/browse/SYS-1036).

This PR adds a display of invoice line item details.  The new page is linked from the main invoice display via the `(details)` link for each invoice line item:
![invoice_line_links](https://user-images.githubusercontent.com/2213836/198113511-dc7e6c74-8288-4586-a81b-a6759eac459a.png)

Which leads to (example):
![invoice_line_details](https://user-images.githubusercontent.com/2213836/198113891-90838340-02b8-4b5c-af82-2cfe92d5faf8.png)

Code changes include:
* Update to underlying database view and model to add a few missing fields
* New URL pattern for linking to invoice line details
* New Django view and access utility for this data

Testing:
* Run `sql_support/initialize_database.sh` to update database objects (no new migrations)
* Search for Invoice `UCLA-058A`
* Marvel at data being displayed on a web page
