### PR TITLE
SYS-1046: List items below MARC holdings records

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 0.0.1
+version: 1.0.1

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.1
+  tag: v0.9.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -69,4 +69,30 @@
 </div>
 {% endif %}
 
+{% if item_summary %}
+<div class="row">
+    <div class="column">
+        <h2>Item Summary</h2>
+        <table class="data-display">
+            <tr>
+                <th>Barcode</th>
+                <th>Location</th>
+                <th>Item Type</th>
+                <th>Enumeration</th>
+            </tr>
+        {% for item in item_summary %}
+            <tr>
+                <td>
+                    <a href="{% url 'item_display' item.item_id %}">{{ item.item_barcode }}</a>
+                </td>
+                <td>{{ item.perm_location }}</td>
+                <td>{{ item.item_type }}</td>
+                <td>{{ item.item_enum }}</td>
+            </tr>
+        {% endfor %}
+        </table>
+    </div>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -83,7 +83,9 @@
         {% for item in item_summary %}
             <tr>
                 <td>
-                    <a href="{% url 'item_display' item.item_id %}">{{ item.item_barcode }}</a>
+                    {% comment %}Some items lack barcodes{% endcomment %}
+                    <a href="{% url 'item_display' item.item_id %}">
+                        {% if item.item_barcode %}{{ item.item_barcode }}{% else %}No barcode{% endif %}</a>
                 </td>
                 <td>{{ item.perm_location }}</td>
                 <td>{{ item.item_type }}</td>

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -23,4 +23,9 @@ urlpatterns = [
         views.marc_display,
         name="marc_display",
     ),
+    path(
+        "item_display/<int:item_id>",
+        views.item_display,
+        name="item_display",
+    ),
 ]

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -21,6 +21,7 @@ def search(request: HttpRequest) -> None:
 
             marc_record = None
             mfhd_summary = None
+            item_summary = None
             inv_header = None
             item = None
             po_header = None
@@ -32,12 +33,13 @@ def search(request: HttpRequest) -> None:
                 mfhd_summary = get_mfhd_summary(search_term)
             elif search_type == "MFHD_ID":
                 marc_record = get_mfhd_record(search_term)
+                item_summary = get_item_summary(search_term)
             elif search_type == "INV_NUMBER":
                 inv_header = get_inv_header(search_term)
                 inv_lines = get_inv_lines(inv_header.invoice_id)
                 inv_adjustments = get_inv_adjustments(inv_header.invoice_id)
             elif search_type == "ITEM_BARCODE":
-                item = get_item(search_term)
+                item = get_item_by_barcode(search_term)
             elif search_type == "PO_NUMBER":
                 po_header = get_po_header(search_term)
                 po_lines = get_po_lines(po_header.po_id)
@@ -49,6 +51,7 @@ def search(request: HttpRequest) -> None:
                 context = {
                     "marc_record": marc_record,
                     "mfhd_summary": mfhd_summary,
+                    "item_summary": item_summary,
                 }
                 return render(request, "voyager_archive/marc_display.html", context)
             elif inv_header:
@@ -80,12 +83,18 @@ def po_line_display(request: HttpRequest, po_line_item_id: int) -> None:
 
 
 def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
+    mfhd_summary = None
+    item_summary = None
     if marc_type == "bib":
         marc_record = get_bib_record(record_id)
+        mfhd_summary = get_mfhd_summary(record_id)
     if marc_type == "mfhd":
         marc_record = get_mfhd_record(record_id)
+        item_summary = get_item_summary(record_id)
     context = {
         "marc_record": marc_record,
+        "mfhd_summary": mfhd_summary,
+        "item_summary": item_summary,
     }
     return render(request, "voyager_archive/marc_display.html", context)
 
@@ -94,3 +103,9 @@ def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> None:
     inv_lines = get_inv_lines_by_line_id(inv_line_item_id)
     context = {"inv_lines": inv_lines}
     return render(request, "voyager_archive/invoice_line_display.html", context)
+
+
+def item_display(request: HttpRequest, item_id: int) -> None:
+    item = get_item_by_id(item_id)
+    context = {"item": item}
+    return render(request, "voyager_archive/item_display.html", context)

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -93,9 +93,21 @@ def get_marc_fields(model_record: type[MARCRecordView]) -> dict:
     return marc_record_dict
 
 
-def get_item(item_barcode: str) -> ItemView:
+def get_item_by_barcode(item_barcode: str) -> ItemView:
     item = get_object_or_404(ItemView, item_barcode=item_barcode)
     return item
+
+
+def get_item_by_id(item_id: int) -> ItemView:
+    item = ItemView.objects.get(item_id=item_id)
+    return item
+
+
+def get_item_summary(mfhd_id: int) -> QuerySet:
+    item_summary = ItemView.objects.filter(mfhd_id=mfhd_id).order_by(
+        "item_sequence_number"
+    )
+    return item_summary
 
 
 def get_vendor(vendor_code: str) -> VendorView:


### PR DESCRIPTION
Implements [SYS-1046](https://jira.library.ucla.edu/browse/SYS-1046).

This PR displays brief item information below MARC holdings records, in `marc_display.html`.  Clicking on an item's barcode goes to the detailed `item_display.html` page for that item.

It also updates the `marc_display` view so that holdings summary now always displays below bib records, and item info always displays below holdings records, regardless of whether they were found via search or URL link.

Bumps tag version to `v0.9.2`.
