### PR TITLE
SYS-1051: Add detailed invoice adjustment display

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.1
+version: 1.0.2

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.2
+  tag: v0.9.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -138,6 +138,7 @@ create or replace view invoice_adjustment_view as
 select
 	pa.payment_id
 ,	pa.object_id as invoice_id
+,	i.invoice_number
 ,	ar.reason_text as description
 ,	i.currency_code
 --	All of our Voyager currencies use 2 decimal places.

--- a/voyager_archive/models.py
+++ b/voyager_archive/models.py
@@ -2454,6 +2454,7 @@ class InvoiceAdjustmentView(models.Model):
     invoice_id = models.DecimalField(
         max_digits=38, decimal_places=0, blank=True, null=True
     )
+    invoice_number = models.CharField(max_length=25, blank=True, null=True)
     description = models.CharField(max_length=50, blank=True, null=True)
     currency_code = models.CharField(max_length=3, blank=True, null=True)
     raw_amount = models.DecimalField(

--- a/voyager_archive/templates/voyager_archive/invoice_adjustment_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_adjustment_display.html
@@ -1,0 +1,62 @@
+{% extends 'voyager_archive/base.html' %}
+{% block content %}
+
+{% comment %}Only one payment per payment_id{% endcomment %}
+<div class="row">
+    <div class="column">
+        <h2>Invoice Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Invoice Number</td>
+                <td>{{ inv_adjustment.invoice_number }}</td>
+            </tr>
+            <tr>
+                <td class="label">Invoice ID</td>
+                <td>{{ inv_adjustment.invoice_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Payment ID</td>
+                <td>{{ inv_adjustment.payment_id }}</td>
+            </tr>
+            <tr>
+                <td class="label">Description</td>
+                <td>{{ inv_adjustment.description }}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="column">
+        <h2>Fund and Price Information</h2>
+        <table class="data-display">
+            <tr>
+                <td class="label">Raw Amount</td>
+                <td>{{ inv_adjustment.raw_amount|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">USD Amount</td>
+                <td>{{ inv_adjustment.usd_amount|floatformat:2 }}</td>
+            </tr>
+            <tr>
+                <td class="label">Currency Code</td>
+                <td>{{ inv_adjustment.currency_code }}</td>
+            </tr>
+            <tr>
+                <td class="label">Ledger Name</td>
+                <td>{{ inv_adjustment.ledger_name }}</td>
+            </tr>
+            <tr>
+                <td class="label">Fund Name</td>
+                <td>{{ inv_adjustment.fund_name }}</td>
+            </tr>
+            <tr>
+                <td class="label">Fund Code</td>
+                <td>{{ inv_adjustment.fund_code }}</td>
+            </tr>
+            <tr>
+                <td class="label">FAU</td>
+                <td>{{ inv_adjustment.fau }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+{% endblock %}

--- a/voyager_archive/templates/voyager_archive/invoice_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_display.html
@@ -76,12 +76,15 @@
         <h2>Invoice Adjustments</h2>
         <table class="data-display">
             <tr>
+                <th>Line #</th>
                 <th>Description</th>
                 <th>Ledger & Fund</th>
                 <th>Amount</th>
             </tr>
             {% for adjustment in inv_adjustments %}
             <tr>
+                {% comment %}No real adjustment numbers, so use loop counter (1-based){% endcomment %}
+                <td>#{{ forloop.counter }} <a href="{% url 'inv_adj_display' adjustment.payment_id %}">(details)</a></td>
                 <td>{{ adjustment.description }}</td>
                 <td>{{ adjustment.ledger_name }} / {{ adjustment.fund_name }}</td>
                 <td>USD ${{ adjustment.usd_amount|floatformat:2 }}</td>

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="inv_line_display",
     ),
     path(
+        "inv_adj_display/<int:payment_id>",
+        views.inv_adj_display,
+        name="inv_adj_display",
+    ),
+    path(
         "marc_display/<str:marc_type>/<int:record_id>",
         views.marc_display,
         name="marc_display",

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -105,6 +105,12 @@ def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> None:
     return render(request, "voyager_archive/invoice_line_display.html", context)
 
 
+def inv_adj_display(request: HttpRequest, payment_id: int) -> None:
+    inv_adjustment = get_inv_adjustment(payment_id)
+    context = {"inv_adjustment": inv_adjustment}
+    return render(request, "voyager_archive/invoice_adjustment_display.html", context)
+
+
 def item_display(request: HttpRequest, item_id: int) -> None:
     item = get_item_by_id(item_id)
     context = {"item": item}

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -157,7 +157,14 @@ def get_inv_lines_by_line_id(inv_line_item_id: int) -> QuerySet:
 
 
 def get_inv_adjustments(invoice_id: int) -> QuerySet:
+    # Gets all invoice adjustments for an invoice
     inv_adjustments = InvoiceAdjustmentView.objects.filter(
         invoice_id=invoice_id
     ).order_by("payment_id")
     return inv_adjustments
+
+
+def get_inv_adjustment(payment_id: int) -> InvoiceAdjustmentView:
+    # Gets one specific invoice adjustment
+    inv_adjustment = InvoiceAdjustmentView.objects.get(payment_id=payment_id)
+    return inv_adjustment


### PR DESCRIPTION
Implements [SYS-1051](https://jira.library.ucla.edu/browse/SYS-1051).

This PR adds the ability to display invoice adjustment details:
* Adds link on `payment_id` from `invoice_display.html` for each invoice adjustment
* Adds new view `inv_adj_display`, with supporting data access and URL routing
* Adds new template `invoice_adjustment_display.html`
* Updates `InvoiceAdjustmentView` model (and underlying database view) to add `invoice_number`
* Bumps version to v0.9.3
