### PR TITLE
SYS-1048: Final pre-launch cleanup

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.2
+version: 1.0.3

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.3
+  tag: v0.9.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -40,3 +40,12 @@
   .label {
     font-weight: bold;
   }
+
+  .marc-tag {
+    max-width: 3ch;
+  }
+  
+  .marc-ind {
+    max-width: 3ch;
+  }
+  

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -22,7 +22,7 @@
   
   table.data-display th, table.data-display td {
     text-align: left;
-    padding: 12px;
+    padding: 6px;
   }
   
   table.data-display tr:nth-child(even) {

--- a/voyager_archive/templates/voyager_archive/invoice_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_display.html
@@ -12,7 +12,7 @@
             <tr>
                 <td class="label">Vendor</td>
                 <td>
-                    {{ inv_header.vendor_code }}
+                    <a href="{% url 'vendor_display' inv_header.vendor_id %}">{{ inv_header.vendor_code }}</a>
                     {% if inv_header.vendor_account_number %}(account {{inv_header.vendor_account_number }}){% endif %}
                 </td>
             </tr>
@@ -113,7 +113,7 @@
                 {% comment %}No real invoice line numbers, so use loop counter (1-based){% endcomment %}
                 <td>#{{ forloop.counter }} <a href="{% url 'inv_line_display' line.inv_line_item_id %}">(details)</a></td>
                 <td>{{ line.status }}</td>
-                <td>{{ line.bib_id }} {{ line.title }}</td>
+                <td><a href="{% url 'marc_display' 'bib' line.bib_id %}">{{ line.title }}</a></td>
                 <td>{% if line.piece_identifier %}{{line.piece_identifier }}{% endif %}</td>
                 <td>{{ line.ledger_name }} / {{ line.fund_name }}</td>
                 <td>USD ${{ line.usd_amount|floatformat:2 }}</td>

--- a/voyager_archive/templates/voyager_archive/invoice_line_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_line_display.html
@@ -12,7 +12,7 @@
             </tr>
             <tr>
                 <td class="label">PO Number</td>
-                <td>{{ line.po_number }}</td>
+                <td><a href="{% url 'po_display' line.po_id %}">{{ line.po_number }}</a></td>
             </tr>
             <tr>
                 <td class="label">Invoice ID</td>
@@ -64,7 +64,7 @@
         <table class="data-display">
             <tr>
                 <td class="label">Bib ID</td>
-                <td>{{ line.bib_id }}</td>
+                <td><a href="{% url 'marc_display' 'bib' line.bib_id %}">{{ line.bib_id }}</a></td>
             </tr>
             <tr>
                 <td class="label">Title</td>

--- a/voyager_archive/templates/voyager_archive/item_display.html
+++ b/voyager_archive/templates/voyager_archive/item_display.html
@@ -15,7 +15,7 @@
             </tr>
             <tr>
                 <td class="label">MFHD ID</td>
-                <td>{{ item.mfhd_id }}</td>
+                <td><a href="{% url 'marc_display' 'mfhd' item.mfhd_id %}">{{ item.mfhd_id }}</a></td>
             </tr>
             <tr>
                 <td class="label">Item Type</td>

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -9,19 +9,19 @@
             display before regular fields.
             {% endcomment %}
             <tr>
-                <td>Suppressed</td>
-                <td></td>
+                <td class="marc-tag">Suppressed</td>
+                <td class="marc-ind"></td>
                 <td>{{ marc_record.suppressed }}</td>
             </tr>
             <tr>
-                <td>LDR</td>
-                <td></td>
+                <td class="marc-tag">LDR</td>
+                <td class="marc-ind"></td>
                 <td>{{ marc_record.leader }}</td>
             </tr>
             {% for field in marc_record.fields %}
             <tr>
-                <td>{{ field.tag }}</td>
-                <td><span class='indicators'>
+                <td class="marc-tag">{{ field.tag }}</td>
+                <td class="marc-ind"><span class="indicators">
                     {{ field.indicator1 }}&nbsp;{{ field.indicator2 }}
                     </span>
                 </td>
@@ -33,7 +33,7 @@
                     {% endif %}
                     {% for delimiter, values in field.subfields.items %}
                         {% for value in values %}
-                            <span class='delimiter'>${{ delimiter }}</span> {{ value }}
+                            <span class="delimiter">${{ delimiter }}</span> {{ value }}
                         {% endfor %}
                     {% endfor %}
                 </td>

--- a/voyager_archive/templates/voyager_archive/po_display.html
+++ b/voyager_archive/templates/voyager_archive/po_display.html
@@ -12,7 +12,7 @@
             <tr>
                 <td class="label">Vendor</td>
                 <td>
-                    {{ po_header.vendor_code }}
+                    <a href="{% url 'vendor_display' po_header.vendor_id %}">{{ po_header.vendor_code }}</a>
                     {% if po_header.vendor_account_number %}(account {{po_header.vendor_account_number }}){% endif %}
                 </td>
             </tr>
@@ -104,7 +104,7 @@
                 <td class="label">
                     #{{ line.line_item_number }} <a href="{% url 'po_line_display' line.line_item_id %}">(details)</a>
                 </td>
-                <td>{{ line.bib_id }} {{ line.title }}</td>
+                <td><a href="{% url 'marc_display' 'bib' line.bib_id %}">{{ line.title }}</a></td>
                 <td>{{ line.line_item_status }} / {{ line.inv_line_status }} ({{ line.status_date }})</td>
                 <td>{% if line.piece_identifer %}{{ line.piece_identifier }}{% endif %}</td>
                 <td>USD ${{ line.usd_amount|floatformat:2 }}</td>

--- a/voyager_archive/templates/voyager_archive/po_line_display.html
+++ b/voyager_archive/templates/voyager_archive/po_line_display.html
@@ -86,20 +86,20 @@
         <h2>Item Information</h2>
         <table class="data-display">
             <tr>
-                <td class="label">Bib ID</td>
-                <td>{{ line.bib_id }}</td>
-            </tr>
-            <tr>
                 <td class="label">Copy ID</td>
                 <td>{{ line.copy_id }}</td>
             </tr>
             <tr>
-                <td class="label">MFHD ID</td>
-                <td>{{ line.mfhd_id }}</td>
-            </tr>
-            <tr>
                 <td class="label">Title</td>
                 <td>{{ line.title }}</td>
+            </tr>
+            <tr>
+                <td class="label">Bib ID</td>
+                <td><a href="{% url 'marc_display' 'bib' line.bib_id %}">{{ line.bib_id }}</a></td>
+            </tr>
+            <tr>
+                <td class="label">MFHD ID</td>
+                <td><a href="{% url 'marc_display' 'mfhd' line.mfhd_id %}">{{ line.mfhd_id }}</a></td>
             </tr>
             <tr>
                 <td class="label">Location Code</td>

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -9,6 +9,11 @@ urlpatterns = [
         name="search",
     ),
     path(
+        "po_display/<int:po_id>",
+        views.po_display,
+        name="po_display",
+    ),
+    path(
         "po_line_display/<int:po_line_item_id>",
         views.po_line_display,
         name="po_line_display",
@@ -32,5 +37,10 @@ urlpatterns = [
         "item_display/<int:item_id>",
         views.item_display,
         name="item_display",
+    ),
+    path(
+        "vendor_display/<int:vendor_id>",
+        views.vendor_display,
+        name="vendor_display",
     ),
 ]

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -82,6 +82,13 @@ def po_line_display(request: HttpRequest, po_line_item_id: int) -> None:
     return render(request, "voyager_archive/po_line_display.html", context)
 
 
+def po_display(request: HttpRequest, po_id: int) -> None:
+    po_header = get_po_header_by_po_id(po_id)
+    po_lines = get_po_lines(po_id)
+    context = {"po_header": po_header, "po_lines": po_lines}
+    return render(request, "voyager_archive/po_display.html", context)
+
+
 def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
     mfhd_summary = None
     item_summary = None
@@ -115,3 +122,10 @@ def item_display(request: HttpRequest, item_id: int) -> None:
     item = get_item_by_id(item_id)
     context = {"item": item}
     return render(request, "voyager_archive/item_display.html", context)
+
+
+def vendor_display(request: HttpRequest, vendor_id: int) -> None:
+    vendor = get_vendor_by_vendor_id(vendor_id)
+    vendor_accts = get_vendor_accts(vendor_id)
+    context = {"vendor": vendor, "vendor_accts": vendor_accts}
+    return render(request, "voyager_archive/vendor_display.html", context)

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -115,6 +115,11 @@ def get_vendor(vendor_code: str) -> VendorView:
     return vendor
 
 
+def get_vendor_by_vendor_id(vendor_id: int) -> VendorView:
+    vendor = VendorView.objects.get(vendor_id=vendor_id)
+    return vendor
+
+
 def get_vendor_accts(vendor_id: int) -> QuerySet:
     vendor_accts = VendorAccountView.objects.filter(vendor_id=vendor_id)
     return vendor_accts
@@ -122,6 +127,11 @@ def get_vendor_accts(vendor_id: int) -> QuerySet:
 
 def get_po_header(po_number: str) -> PoHeaderView:
     po_header = get_object_or_404(PoHeaderView, po_number=po_number)
+    return po_header
+
+
+def get_po_header_by_po_id(po_id: int) -> PoHeaderView:
+    po_header = PoHeaderView.objects.get(po_id=po_id)
     return po_header
 
 


### PR DESCRIPTION
Implements [SYS-1048](https://jira.library.ucla.edu/browse/SYS-1048) and more.

This PR:
* Adds links where they did not previously exist, to
  * vendor codes on invoice and purchase order headers
  * po numbers on invoice line details
  * mfhd ids on item details
  * titles (via bib id) on invoice and po lines
* Adds URL routes, views, and data access methods to support the above
* Reduces table cell padding to make table displays more compact
* Adds and applies CSS to MARC columns for tags and indicators (the 1st 2 columns in MARC record display) to reduce their width
* Bumps version to `v0.9.4`


Testing:
* No restart necessary
* Search Invoice Number = `UCLA-058A`
* Click on anything clickable (though only the 2nd title, [Edo hanpon shūyō /](http://127.0.0.1:8000/marc_display/bib/9411434), has sample data).
* You should be able to navigate from 
  * invoice -> vendor
  * invoice -> adjustment
  * invoice -> line item
  * line item -> bib record
  * bib record -> holdings record
  * holdings (mfhd) record -> item (via barcode)
  * item -> mfhd record
  * mfhd record -> bib record (via 004 field)
