### PR TITLE
SYS-1055: Tweak displays

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.3
+version: 1.0.4

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.4
+  tag: v0.9.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -182,7 +182,7 @@ select
 ,	ili.piece_identifier
 ,	ilif.split_fund_seq
 ,	round((ilif.percentage / 1000000), 2) as percentage
-,	ilif.amount / 100 as usd_amount
+,	get_usd_amount(ilif.amount, i.conversion_rate) / 100 as usd_amount
 ,	l.ledger_name
 ,	f.fund_name
 ,	f.fund_code
@@ -275,7 +275,7 @@ select
 ,	get_usd_amount(li.line_price, po.conversion_rate) / 100 as line_price
 ,	lif.split_fund_seq
 ,	round((lif.percentage / 1000000), 2) as percentage
-,	lif.amount as raw_amount
+,	lif.amount / 100 as raw_amount
 ,	get_usd_amount(lif.amount, po.conversion_rate) / 100 as usd_amount
 ,	li.quantity
 ,	lg.ledger_name

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -12,17 +12,35 @@
     flex: 50%;
     padding: 5px;
   }
-  
-  table.data-display {
+
+  table.marc-display {
     border-collapse: collapse;
     border-spacing: 0;
     table-layout: fixed;
     width: 100%;
     border: 1px solid #ddd;
   }
+
+  table.marc-display th, table.marc-display td {
+    text-align: left;
+    vertical-align: top;
+    padding: 6px;
+  }
   
+  table.marc-display tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  table.data-display {
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+    border: 1px solid #ddd;
+  }
+
   table.data-display th, table.data-display td {
     text-align: left;
+    vertical-align: top;
     padding: 6px;
   }
   

--- a/voyager_archive/static/css/style.css
+++ b/voyager_archive/static/css/style.css
@@ -16,6 +16,7 @@
   table.data-display {
     border-collapse: collapse;
     border-spacing: 0;
+    table-layout: fixed;
     width: 100%;
     border: 1px solid #ddd;
   }
@@ -42,10 +43,10 @@
   }
 
   .marc-tag {
-    max-width: 3ch;
+    width: 15ch;
   }
   
   .marc-ind {
-    max-width: 3ch;
+    width: 5ch;
   }
   

--- a/voyager_archive/templates/voyager_archive/invoice_line_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_line_display.html
@@ -97,7 +97,7 @@
             </tr>
             <tr>
                 <td class="label">USD Amount</td>
-                <td>{{ line.usd_amount|floatformat:2 }}</td>
+                <td>USD ${{ line.usd_amount|floatformat:2 }}</td>
             </tr>
             <tr>
                 <td class="label">Quantity</td>

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -9,13 +9,11 @@
             display before regular fields.
             {% endcomment %}
             <tr>
-                <td class="marc-tag">Suppressed</td>
-                <td class="marc-ind"></td>
+                <td class="marc-tag" colspan="2">Suppressed</td>
                 <td>{{ marc_record.suppressed }}</td>
             </tr>
             <tr>
-                <td class="marc-tag">LDR</td>
-                <td class="marc-ind"></td>
+                <td class="marc-tag" colspan="2">LDR</td>
                 <td>{{ marc_record.leader }}</td>
             </tr>
             {% for field in marc_record.fields %}

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="row">
     <div class="column">
-        <table class="data-display">
+        <table class="marc-display">
             {% comment %}
             Leader and suppression info are special;
             display before regular fields.

--- a/voyager_archive/templates/voyager_archive/po_line_display.html
+++ b/voyager_archive/templates/voyager_archive/po_line_display.html
@@ -132,7 +132,7 @@
             </tr>
             <tr>
                 <td class="label">USD Amount</td>
-                <td>{{ line.usd_amount|floatformat:2 }}</td>
+                <td>USD ${{ line.usd_amount|floatformat:2 }}</td>
             </tr>
             <tr>
                 <td class="label">Quantity</td>

--- a/voyager_archive/templates/voyager_archive/vendor_display.html
+++ b/voyager_archive/templates/voyager_archive/vendor_display.html
@@ -75,8 +75,8 @@
     <div class="column">
         {% if vendor_accts %}
         <h2>Vendor Account Information</h2>
-        {% for acct in vendor_accts %}
         <table class="data-display">
+            {% for acct in vendor_accts %}
             <tr>
                 <td class="label">Account Name</td>
                 <td>{{ acct.account_name }}</td>
@@ -101,12 +101,12 @@
                 <td class="label">Default PO Type</td>
                 <td>{{ acct.default_po_type }}</td>
             </tr>
+            {% if not forloop.last %}
+            <hr>
+            {% endif %}
+            {% endfor %}
         </table>
-        {% if not forloop.last %}
-        <hr>
-        {% endif %}
-        {% endfor %}
-        {% endif %}
+    {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Implements [SYS-1055](https://jira.library.ucla.edu/browse/SYS-1055).

This PR:
* Fixes MARC table display problems
  * Combines tag and indicators in one cell
  * Adjusts column width to protect tag/indicators from long fields
  * Uses separate classes for MARC display and other data display
* Sets `vertical-align: top` for MARC & other data display
* Displays `USD $` next to guaranteed USD amounts
* Fixes bugs in 2 database views which did not correctly convert to USD
* Fixes bug in database view which did not convert whole number (cents) to float (dollars & cents)
* Bump version to `v0.9.5`
