### PR TITLE
SYS-1056: Handle search duplicates

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.6
+version: 1.0.7

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.7
+  tag: v0.9.8
   pullPolicy: Always
 
 nameOverride: ""

--- a/sql_support/sample_data.sql
+++ b/sql_support/sample_data.sql
@@ -33,6 +33,7 @@ SET synchronous_commit TO off;
 
 COPY mfhd_item (mfhd_id,item_id,item_enum,chron,year,caption,freetext) FROM STDIN;
 12507598	12066882	v.1-2	\N	\N	\N	\N
+12507598	99999999	v.1-2	\N	\N	\N	\N
 \.
 
 COMMIT;
@@ -45,6 +46,7 @@ SET synchronous_commit TO off;
 
 COPY item_barcode (item_id,item_barcode,barcode_status,barcode_status_date) FROM STDIN;
 12066882	L0112367321	1	2020-12-16 05:01:56
+99999999	L0112367321	1	2020-12-16 05:01:56
 \.
 
 COMMIT;
@@ -57,6 +59,7 @@ SET synchronous_commit TO off;
 
 COPY item (item_id,perm_location,temp_location,item_type_id,temp_item_type_id,copy_number,on_reserve,reserve_charges,pieces,price,spine_label,historical_charges,historical_browses,recalls_placed,holds_placed,create_date,modify_date,create_operator_id,modify_operator_id,create_location_id,modify_location_id,item_sequence_number,historical_bookings,media_type_id,short_loan_charges,magnetic_media,sensitize) FROM STDIN;
 12066882	146	0	2	0	0	N	0	1	0	\N	0	0	0	0	2020-12-16 05:01:56	2020-12-16 09:26:46	uclaloader	jtanaka	203	148	1	0	0	0	N	Y
+99999999	146	0	2	0	0	N	0	1	0	\N	0	0	0	0	2020-12-16 05:01:56	2020-12-16 09:26:46	uclaloader	jtanaka	203	148	1	0	0	0	N	Y
 \.
 
 COMMIT;
@@ -446,6 +449,7 @@ SET synchronous_commit TO off;
 
 COPY vendor (vendor_id,vendor_type,normal_vendor_type,vendor_code,normal_vendor_code,vendor_name,normal_vendor_name,federal_tax_id,institution_id,default_currency,claim_interval,claim_count,cancel_interval,ship_via,create_date,create_opid,update_date,update_opid) FROM STDIN;
 3764	VE	VE	LQZ	LQZ	Library of Congress Cataloging Distribution Service	LIBRARY OF CONGRESS CATALOGING DISTRIBUTION SERVICE	\N	006039003	\N	0	0	0	\N	2004-06-04 11:33:09	CONVERSION	2021-05-21 11:14:52	rrivero
+9999	VE	VE	LQZ	LQZ	DUP Library of Congress Cataloging Distribution Service	LIBRARY OF CONGRESS CATALOGING DISTRIBUTION SERVICE	\N	006039003	\N	0	0	0	\N	2004-06-04 11:33:09	CONVERSION	2021-05-21 11:14:52	rrivero
 \.
 
 COMMIT;

--- a/voyager_archive/templates/voyager_archive/invoice_display.html
+++ b/voyager_archive/templates/voyager_archive/invoice_display.html
@@ -17,6 +17,10 @@
                 </td>
             </tr>
             <tr>
+                <td class="label">Invoice Date</td>
+                <td>{{ inv_header.invoice_date|date:"DATE_FORMAT" }}</td>
+            </tr>
+            <tr>
                 <td class="label">Voucher Number</td>
                 <td>{{ inv_header.voucher_number }}</td>
             </tr>

--- a/voyager_archive/templates/voyager_archive/invoice_results.html
+++ b/voyager_archive/templates/voyager_archive/invoice_results.html
@@ -1,0 +1,22 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+{% if inv_headers %}
+<table class="data-display">
+    <tr>
+        <th>Invoice Number</th>
+        <th>Vendor Code</th>
+        <th>Invoice Date</th>
+    </tr>
+    {% for inv_header in inv_headers %}
+    <tr>
+        <td><a href="{% url 'invoice_display' inv_header.invoice_id %}">{{ inv_header.invoice_number }}</a></td>
+        <td>{{ inv_header.vendor_code }}</td>
+        <td>{{ inv_header.invoice_date|date:"DATE_FORMAT" }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>Your search found no invoices.</p>
+{% endif %}
+{% endblock %}

--- a/voyager_archive/templates/voyager_archive/item_results.html
+++ b/voyager_archive/templates/voyager_archive/item_results.html
@@ -1,0 +1,28 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+{% if items %}
+<table class="data-display">
+    <tr>
+        <th>Barcode</th>
+        <th>Location</th>
+        <th>Item Type</th>
+        <th>Enumeration</th>
+    </tr>
+    {% for item in items %}
+    <tr>
+        <td>
+            {% comment %}Some items lack barcodes{% endcomment %}
+            <a href="{% url 'item_display' item.item_id %}">
+                {% if item.item_barcode %}{{ item.item_barcode }}{% else %}No barcode{% endif %}</a>
+        </td>
+        <td>{{ item.perm_location }}</td>
+        <td>{{ item.item_type }}</td>
+        <td>{{ item.item_enum }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>Your search found no items.</p>
+{% endif %}
+{% endblock %}

--- a/voyager_archive/templates/voyager_archive/po_results.html
+++ b/voyager_archive/templates/voyager_archive/po_results.html
@@ -1,0 +1,22 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+{% if po_headers %}
+<table class="data-display">
+    <tr>
+        <th>PO Number</th>
+        <th>Vendor Code</th>
+        <th>Approved Date</th>
+    </tr>
+    {% for po_header in po_headers %}
+    <tr>
+        <td><a href="{% url 'po_display' po_header.po_id %}">{{ po_header.po_number }}</a></td>
+        <td>{{ po_header.vendor_code }}</td>
+        <td>{{ po_header.approve_date }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>Your search found no purchase orders.</p>
+{% endif %}
+{% endblock %}

--- a/voyager_archive/templates/voyager_archive/vendor_results.html
+++ b/voyager_archive/templates/voyager_archive/vendor_results.html
@@ -1,0 +1,20 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+{% if vendors %}
+<table class="data-display">
+    <tr>
+        <th>Vendor Code</th>
+        <th>Vendor Name</th>
+    </tr>
+    {% for vendor in vendors %}
+    <tr>
+        <td><a href="{% url 'vendor_display' vendor.vendor_id %}">{{ vendor.vendor_code }}</a></td>
+        <td>{{ vendor.vendor_name }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>Your search found no vendors.</p>
+{% endif %}
+{% endblock %}

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="po_line_display",
     ),
     path(
+        "invoice_display/<int:invoice_id>",
+        views.invoice_display,
+        name="invoice_display",
+    ),
+    path(
         "inv_line_display/<int:inv_line_item_id>",
         views.inv_line_display,
         name="inv_line_display",

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -1,5 +1,5 @@
 import logging
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse
 from .views_utils import *
@@ -18,14 +18,9 @@ def search(request: HttpRequest) -> None:
             logger.info(f"Form data: {form.cleaned_data}")
             search_type = form.cleaned_data["search_type"]
             search_term = form.cleaned_data["search_term"]
-
             marc_record = None
             mfhd_summary = None
             item_summary = None
-            inv_header = None
-            item = None
-            po_header = None
-            vendor = None
             if search_type == "AUTH_ID":
                 marc_record = get_auth_record(search_term)
             elif search_type == "BIB_ID":
@@ -35,17 +30,41 @@ def search(request: HttpRequest) -> None:
                 marc_record = get_mfhd_record(search_term)
                 item_summary = get_item_summary(search_term)
             elif search_type == "INV_NUMBER":
-                inv_header = get_inv_header(search_term)
-                inv_lines = get_inv_lines(inv_header.invoice_id)
-                inv_adjustments = get_inv_adjustments(inv_header.invoice_id)
+                inv_headers = get_inv_headers(search_term)
+                # If only 1, show directly; otherwise, show search results
+                if len(inv_headers) == 1:
+                    return redirect("invoice_display", inv_headers[0].invoice_id)
+                else:
+                    context = {"inv_headers": inv_headers}
+                    return render(
+                        request, "voyager_archive/invoice_results.html", context
+                    )
             elif search_type == "ITEM_BARCODE":
-                item = get_item_by_barcode(search_term)
+                items = get_items(search_term)
+                # If only 1, show directly; otherwise, show search results
+                if len(items) == 1:
+                    return redirect("item_display", items[0].item_id)
+                else:
+                    context = {"items": items}
+                    return render(request, "voyager_archive/item_results.html", context)
             elif search_type == "PO_NUMBER":
-                po_header = get_po_header(search_term)
-                po_lines = get_po_lines(po_header.po_id)
+                po_headers = get_po_headers(search_term)
+                # If only 1, show directly; otherwise, show search results
+                if len(po_headers) == 1:
+                    return redirect("po_display", po_headers[0].po_id)
+                else:
+                    context = {"po_headers": po_headers}
+                    return render(request, "voyager_archive/po_results.html", context)
             elif search_type == "VENDOR_CODE":
-                vendor = get_vendor(search_term)
-                vendor_accts = get_vendor_accts(vendor.vendor_id)
+                vendors = get_vendors(search_term)
+                # If only 1, show directly; otherwise, show search results
+                if len(vendors) == 1:
+                    return redirect("vendor_display", vendors[0].vendor_id)
+                else:
+                    context = {"vendors": vendors}
+                    return render(
+                        request, "voyager_archive/vendor_results.html", context
+                    )
 
             if marc_record:
                 context = {
@@ -54,22 +73,6 @@ def search(request: HttpRequest) -> None:
                     "item_summary": item_summary,
                 }
                 return render(request, "voyager_archive/marc_display.html", context)
-            elif inv_header:
-                context = {
-                    "inv_header": inv_header,
-                    "inv_lines": inv_lines,
-                    "inv_adjustments": inv_adjustments,
-                }
-                return render(request, "voyager_archive/invoice_display.html", context)
-            elif item:
-                context = {"item": item}
-                return render(request, "voyager_archive/item_display.html", context)
-            elif po_header:
-                context = {"po_header": po_header, "po_lines": po_lines}
-                return render(request, "voyager_archive/po_display.html", context)
-            elif vendor:
-                context = {"vendor": vendor, "vendor_accts": vendor_accts}
-                return render(request, "voyager_archive/vendor_display.html", context)
     else:
         # No POST, no search done, use blank form included in base context
         context = {}
@@ -104,6 +107,18 @@ def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
         "item_summary": item_summary,
     }
     return render(request, "voyager_archive/marc_display.html", context)
+
+
+def invoice_display(request: HttpRequest, invoice_id: int) -> None:
+    inv_header = get_inv_header_by_inv_id(invoice_id)
+    inv_lines = get_inv_lines(invoice_id)
+    inv_adjustments = get_inv_adjustments(invoice_id)
+    context = {
+        "inv_header": inv_header,
+        "inv_lines": inv_lines,
+        "inv_adjustments": inv_adjustments,
+    }
+    return render(request, "voyager_archive/invoice_display.html", context)
 
 
 def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> None:

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -93,9 +93,9 @@ def get_marc_fields(model_record: type[MARCRecordView]) -> dict:
     return marc_record_dict
 
 
-def get_item_by_barcode(item_barcode: str) -> ItemView:
-    item = get_object_or_404(ItemView, item_barcode=item_barcode)
-    return item
+def get_items(item_barcode: str) -> QuerySet:
+    items = ItemView.objects.filter(item_barcode=item_barcode).order_by("mfhd_id")
+    return items
 
 
 def get_item_by_id(item_id: int) -> ItemView:
@@ -110,9 +110,9 @@ def get_item_summary(mfhd_id: int) -> QuerySet:
     return item_summary
 
 
-def get_vendor(vendor_code: str) -> VendorView:
-    vendor = get_object_or_404(VendorView, vendor_code=vendor_code)
-    return vendor
+def get_vendors(vendor_code: str) -> QuerySet:
+    vendors = VendorView.objects.filter(vendor_code=vendor_code).order_by("vendor_name")
+    return vendors
 
 
 def get_vendor_by_vendor_id(vendor_id: int) -> VendorView:
@@ -125,9 +125,11 @@ def get_vendor_accts(vendor_id: int) -> QuerySet:
     return vendor_accts
 
 
-def get_po_header(po_number: str) -> PoHeaderView:
-    po_header = get_object_or_404(PoHeaderView, po_number=po_number)
-    return po_header
+def get_po_headers(po_number: str) -> QuerySet:
+    po_headers = PoHeaderView.objects.filter(po_number=po_number).order_by(
+        "-approve_date"
+    )
+    return po_headers
 
 
 def get_po_header_by_po_id(po_id: int) -> PoHeaderView:
@@ -147,9 +149,16 @@ def get_po_lines_by_line_id(line_item_id: int) -> QuerySet:
     return po_lines
 
 
-def get_inv_header(inv_number: str) -> InvoiceHeaderView:
-    inv_header = get_object_or_404(InvoiceHeaderView, invoice_number=inv_number)
+def get_inv_header_by_inv_id(invoice_id: int) -> InvoiceHeaderView:
+    inv_header = InvoiceHeaderView.objects.get(invoice_id=invoice_id)
     return inv_header
+
+
+def get_inv_headers(inv_number: str) -> QuerySet:
+    inv_headers = InvoiceHeaderView.objects.filter(invoice_number=inv_number).order_by(
+        "vendor_code"
+    )
+    return inv_headers
 
 
 def get_inv_lines(invoice_id: int) -> QuerySet:


### PR DESCRIPTION
Implements [SYS-1056](https://jira.library.ucla.edu/browse/SYS-1056).

This PR reworks searching so that searches which can return multiple records (PO numbers, invoice numbers, vendor codes, and item barcodes) work correctly.  

If only one record of any type is found, the user sees the full display.  This is the normal behavior.  

If a search finds multiple records, an intermediate display lists them, with enough additional information to help the user decide which record is wanted.  Each record has a link taking the user to the full display.

For the given record types (PO, invoice, vendor, item), if a search finds no records, a message will display.  For other types (MARC records), if a search finds no records, the user will get a 404 page.  This is because searches for MARC records will never find duplicates, so there's no intermediate display.  This is an inconsistency which could be addressed in future, but would take too much time to address now.

Testing:
* Run `sql_support/initialize_database.sh` to update sample data
* Search for: Item barcode = `L0112367321`.  2 items appear; click to view details on each (only the `item_id` differs on these samples).
* Search for: Vendor code = `LQZ`.  2 vendors appear; click to view details.  Vendor name differs on these.
* Search for: Vendor code = `YAGI`.  The full vendor screen appears.
* Search for: PO number = `FROG` (or whatever).  A message says `Your search found no purchase orders.`  Sample data for POs and invoices is too hard to duplicate, but I tested and confirmed that the intermediate screen appears correctly for these types as well.

Other changes:
* Added one new URL route, for `invoice_display`, which previously was only via search.
* Added fake sample data sufficient to test duplicate items and vendors.
* Added `Invoice Date` to full invoice display, which I somehow missed before.
* Bumped version to `v0.9.8`.