### PR TITLE
SYS-1058: Add item status and stat cats

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.7
+version: 1.0.8

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.8
+  tag: v0.9.9
   pullPolicy: Always
 
 nameOverride: ""

--- a/sql_support/create_psql_views.sql
+++ b/sql_support/create_psql_views.sql
@@ -34,6 +34,8 @@ select
 ,	i.modify_operator_id
 ,	(select location_code from location where location_id = i.modify_location_id) as modify_location
 ,	i.item_sequence_number
+,	get_all_item_status(i.item_id) as item_status
+,	get_all_item_stat_cats(i.item_id) as item_stat_cats
 from item i
 inner join mfhd_item mi on i.item_id = mi.item_id
 inner join location l1 on i.perm_location = l1.location_id

--- a/voyager_archive/models.py
+++ b/voyager_archive/models.py
@@ -2355,6 +2355,8 @@ class ItemView(models.Model):
     item_sequence_number = models.DecimalField(
         max_digits=38, decimal_places=0, blank=True, null=True
     )
+    item_status = models.TextField(blank=True, null=True)
+    item_stat_cats = models.TextField(blank=True, null=True)
 
     class Meta:
         managed = False  # Created from a view. Don't remove.

--- a/voyager_archive/templates/voyager_archive/item_display.html
+++ b/voyager_archive/templates/voyager_archive/item_display.html
@@ -26,6 +26,14 @@
                 <td>{{ item.temp_item_type }}</td>
             </tr>
             <tr>
+                <td class="label">Item Status</td>
+                <td>{{ item.item_status }}</td>
+            </tr>
+            <tr>
+                <td class="label">Item Stat Cats</td>
+                <td>{{ item.item_stat_cats }}</td>
+            </tr>
+            <tr>
                 <td class="label">Enumeration</td>
                 <td>{{ item.item_enum }}</td>
             </tr>


### PR DESCRIPTION
Implements [SYS-1058](https://jira.library.ucla.edu/browse/SYS-1058).

This PR adds `item_status` and `item_stat_cats` (categories) to the `ItemView` model and underlying database view.  The database functions which provide this data already existed, but were never added to the database view.

The full `item_display.html` now shows these fields, though I didn't add sample data to support this locally.

Bumped version to `v0.9.9`.
