### PR TITLE
SYS-1059: Add error handling for MARC searches

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.15
+version: 1.0.16

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v0.9.9g
+  tag: v1.0.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/voyager_archive/templates/404.html
+++ b/voyager_archive/templates/404.html
@@ -1,0 +1,6 @@
+{% extends 'voyager_archive/base.html' %}
+{% block content %}
+
+<p>{{ exception }}</p>
+
+{% endblock %}

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -1,5 +1,6 @@
-from django.shortcuts import get_object_or_404
 from django.http.request import HttpRequest  # for code completion
+from django.http import Http404
+from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
 from pymarc import Record
 from .forms import VoyArchiveForm
@@ -31,17 +32,32 @@ def get_search_form(request: HttpRequest = None) -> VoyArchiveForm:
 
 
 def get_auth_record(auth_id: int) -> AuthRecordView:
-    model_record = get_object_or_404(AuthRecordView, marc_record_id=auth_id)
+    try:
+        model_record = AuthRecordView.objects.get(marc_record_id=auth_id)
+    except AuthRecordView.DoesNotExist:
+        raise Http404(f"Authority record {auth_id} does not exist.")
+    except ValidationError:
+        raise Http404(f"{auth_id} is not a valid record id.")
     return get_marc_fields(model_record)
 
 
 def get_bib_record(bib_id: int) -> BibRecordView:
-    model_record = get_object_or_404(BibRecordView, marc_record_id=bib_id)
+    try:
+        model_record = BibRecordView.objects.get(marc_record_id=bib_id)
+    except BibRecordView.DoesNotExist:
+        raise Http404(f"Bibliographic record {bib_id} does not exist.")
+    except ValidationError:
+        raise Http404(f"{bib_id} is not a valid record id.")
     return get_marc_fields(model_record)
 
 
 def get_mfhd_record(mfhd_id: int) -> MfhdRecordView:
-    model_record = get_object_or_404(MfhdRecordView, marc_record_id=mfhd_id)
+    try:
+        model_record = MfhdRecordView.objects.get(marc_record_id=mfhd_id)
+    except MfhdRecordView.DoesNotExist:
+        raise Http404(f"Holdings record {mfhd_id} does not exist.")
+    except ValidationError:
+        raise Http404(f"{mfhd_id} is not a valid record id.")
     return get_marc_fields(model_record)
 
 


### PR DESCRIPTION
Implements [SYS-1059](https://jira.library.ucla.edu/browse/SYS-1059).

This PR adds basic error handling for MARC searches.
* If a record id is valid but not found, show custom 404 page with record not message.
* If a record id is not valid (not an integer), show custom 404 page with id not valid message.

Bumps version to `v1.0.0`.
