### PR TITLE
SYS-1675: Image and security updates

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -31,8 +31,10 @@ jobs:
         run: echo "${{ steps.yaml-data.outputs.data }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: uclalibrary/voyager-archive:${{ steps.yaml-data.outputs.data }}
+          tags: |
+            uclalibrary/voyager-archive:${{ steps.yaml-data.outputs.data }}
+            uclalibrary/voyager-archive:scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Debian repository management
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ It is limited to a variety of known-item searches (record ids, po numbers, invoi
 
 The development environment requires:
 * git
-* docker (current version recommended: 20.10.12)
-* docker-compose (at least version 1.25.0; current recommended: 1.29.2)
+* docker (current version recommended: 27.0.3)
+* docker compose (now part of docker itself)
 
 #### PostgreSQL container
 
@@ -20,8 +20,8 @@ The development database is PostgreSQL 12.
 
 #### Django container
 
-This uses Django 4.1, which requires Python 3.8 or later; the container uses Python 3.9.
-It shouldn't matter if Python 3.9 is used locally, as all code runs in the container.
+This uses Django 4.2, which requires Python 3.8 or later; the container uses Python 3.12.
+It shouldn't matter what version of Python is used locally, as all code runs in the container.
 
 The container runs via `docker_scripts/entrypoint.sh`, which
 * Updates container with any new requirements, if the image hasn't been rebuilt (DEV environment only).
@@ -32,7 +32,12 @@ The container runs via `docker_scripts/entrypoint.sh`, which
 
 #### pgAdmin container
 
-For convenience during development, pgAdmin 4 is available.
+For convenience during development, pgAdmin 4 is optionally available.
+Start the system via:
+`docker compose -f docker-compose_PGADMIN.yml up -d`
+Be sure to specify the file when stopping too:
+`docker compose -f docker-compose_PGADMIN.yml down`
+
 * [Login page](http://localhost:5050)
 * Log in with `PGADMIN_DEFAULT_*` credentials from `docker_compose.yml`
 * First time: Register a server.
@@ -53,28 +58,28 @@ For convenience during development, pgAdmin 4 is available.
 
 3. Build using docker-compose.
 
-   `$ docker-compose build`
+   `$ docker compose build`
 
 4. Bring the system up, with containers running in the background.
 
-   `$ docker-compose up -d`
+   `$ docker compose up -d`
 
 5. Logs can be viewed, if needed (`-f` to tail logs).
 
    ```
-   $ docker-compose logs -f db
-   $ docker-compose logs -f django
+   $ docker compose logs -f db
+   $ docker compose logs -f django
    ```
 
 6. Run commands in the containers, if needed.
 
    ```
-   $ docker-compose exec db psql -U voyager_archive
-   $ docker-compose exec django bash
+   $ docker compose exec db psql -U voyager_archive
+   $ docker compose exec django bash
    # Django-aware Python shell
-   $ docker-compose exec django python manage.py shell
+   $ docker compose exec django python manage.py shell
    # Apply new migrations without a restart
-   $ docker-compose exec django python manage.py migrate
+   $ docker compose exec django python manage.py migrate
    ```
 To create database objects and load sample data, see [Database setup](#database-setup-initial).
 
@@ -84,11 +89,11 @@ To create database objects and load sample data, see [Database setup](#database-
 
 8. Edit code locally.  All changes are immediately available in the running container, but if a restart is needed:
 
-   `$ docker-compose restart django`
+   `$ docker compose restart django`
 
 9. Shut down the system when done.
 
-   `$ docker-compose down`
+   `$ docker compose down`
 
 ### Database setup (Initial)
 

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,7 @@ image:
   # the same image automatically, set application tag version
   # here (once) instead of in each environment-specific values file.
   # TODO: How to correctly handle this if we add a test cluster?
-  tag: v1.0.1
+  tag: v1.0.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose_PGADMIN.yml
+++ b/docker-compose_PGADMIN.yml
@@ -20,6 +20,22 @@ services:
       - .docker-compose_db.env
     volumes:
       - pg_data:/var/lib/postgresql/data/
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - "5050:80"
+    environment:
+      # These are fake, for local docker-compose use
+      PGADMIN_DEFAULT_EMAIL: systems@library.ucla.edu
+      PGADMIN_DEFAULT_PASSWORD: admin
+    depends_on:
+      - db
+    extra_hosts:
+      # For access to remote database via ssh tunnel on host
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
 
 volumes:
   pg_data:
+  pgadmin_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==4.2.11
-psycopg2==2.9.3
-gunicorn==20.1.0
-whitenoise==6.2.0
-pymarc==4.2.0
+Django==4.2.16
+psycopg2==2.9.7
+gunicorn==23.0.0
+whitenoise==6.5.0
+pymarc==5.2.2

--- a/sql_support/initialize_database.sh
+++ b/sql_support/initialize_database.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Run this in the local environment, after docker-compose up,
+# Run this in the local environment, after docker compose up,
 # from the root of the project - the same directory as docker-compose.yml
 # If any problems, shut down and restart the docker-compose system.
 
 # Create database objects
-docker-compose exec -T db psql -U voyager_archive < sql_support/create_psql_tables.sql
-docker-compose exec -T db psql -U voyager_archive < sql_support/create_psql_functions.sql
-docker-compose exec -T db psql -U voyager_archive < sql_support/create_psql_views.sql
+docker compose exec -T db psql -U voyager_archive < sql_support/create_psql_tables.sql
+docker compose exec -T db psql -U voyager_archive < sql_support/create_psql_functions.sql
+docker compose exec -T db psql -U voyager_archive < sql_support/create_psql_views.sql
 
 # Load sample data
-docker-compose exec -T db psql -U voyager_archive < sql_support/sample_data.sql
+docker compose exec -T db psql -U voyager_archive < sql_support/sample_data.sql


### PR DESCRIPTION
Implements [SYS-1675](https://uclalibrary.atlassian.net/browse/SYS-1675).  Bumps version to `v1.0.2` for deployment.
The version update is done via the generic `values.yaml` because we build one image which is then deployed as 3 separate applications, all using the same image... so we manage version in one file instead of three.

Upgrades without functionality changes. Includes:
* Updated base image to use Debian 12 and Python 3.12
* Updated Django to 4.2.16 and gunicorn to 23.0.0 to address security alerts.
* Updated whitenoise, psycopg2, and pymarc to latest versions.
* Removed version declaration from docker-compose files
* Split pgadmin support into separate, non-default docker-compose file.
* Updated workflows to use latest actions versions and added `scan` tag to Docker Hub image

Build logs should be clean: `docker compose --progress plain build > build.log`

There are only 2 tests, both trivial, but they should pass: `docker-compose exec django python manage.py test`

There is an additional step required if you've not worked with this application before.  After building and starting the system, run:
`sql_support/initialize_database.sh`

Since this uses a legacy database, the database tables are not managed by Django: there are models, but they do not create tables.  There also are no fixtures, for related reasons.  For more details (optional), see `sql_support/SQL_SUPPORT.md` .

The [application](http://127.0.0.1:8000/) should run, displaying a form.  To confirm that sample data loaded and is displayed correctly, search for "Bib record id" = 9411434

Scroll through the record, confirm all looks OK, click links at the bottom to view linked holdings, etc.


[SYS-1675]: https://uclalibrary.atlassian.net/browse/SYS-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ