### PR TITLE
SYS-1677: Fix MARC display bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,12 @@ The current log format includes:
 * Logger name: to distinguish between sources of messages (`django` vs `voyager_archive` application)
 * Module: somewhat redundant with logger name
 * Message: The main thing being logged
+
+### Deployment Process
+The image for this application is deployed into 3 instances, each pointing at a separate database:
+* [Ethnomusicology Archive](https://ethno-voy-archive.library.ucla.edu/)
+* [Film and Television Archive](https://ftva-voy-archive.library.ucla.edu/)
+* [UCLA Library Archive](https://ucla-voy-archive.library.ucla.edu/)
+
+This means that the `image.tag` property in all 3 Helm chart values files (`charts/prod-*-values.yaml`)
+must be updated, and identical.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Voyager Archive application
 name: voyager-archive
-version: 1.0.18
+version: 1.1.0

--- a/charts/prod-ethnovoyagerarchive-values.yaml
+++ b/charts/prod-ethnovoyagerarchive-values.yaml
@@ -7,9 +7,8 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/voyager-archive
-  # tag is *not* set here, but in the generic values.yaml instead.
-  # This avoids setting tag version in all 3 environment-specific values files.
-  # TODO: How to correctly handle this if we add a test cluster?
+  # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
+  tag: 1.1.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ftvavoyagerarchive-values.yaml
+++ b/charts/prod-ftvavoyagerarchive-values.yaml
@@ -7,9 +7,8 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/voyager-archive
-  # tag is *not* set here, but in the generic values.yaml instead.
-  # This avoids setting tag version in all 3 environment-specific values files.
-  # TODO: How to correctly handle this if we add a test cluster?
+  # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
+  tag: 1.1.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -7,9 +7,8 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/voyager-archive
-  # tag is *not* set here, but in the generic values.yaml instead.
-  # This avoids setting tag version in all 3 environment-specific values files.
-  # TODO: How to correctly handle this if we add a test cluster?
+  # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
+  tag: 1.1.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/voyager_archive/templates/voyager_archive/marc_display.html
+++ b/voyager_archive/templates/voyager_archive/marc_display.html
@@ -27,7 +27,12 @@
                     {% if field.tag == "004" %}
                     <a href="{% url 'marc_display' 'bib' field.data %}">{{ field.data }}</a>
                     {% else %}
-                    {{ field.data }}
+                        {% comment %}
+                        Fixed fields (001-009) have field.data; 010-999 have subfields, below.
+                        {% endcomment %}
+                        {% if field.data %}
+                            {{ field.data }}
+                        {% endif %}
                     {% endif %}
                     {% for delimiter, values in field.subfields.items %}
                         {% for value in values %}

--- a/voyager_archive/templates/voyager_archive/release_notes.html
+++ b/voyager_archive/templates/voyager_archive/release_notes.html
@@ -1,0 +1,22 @@
+{% extends 'voyager_archive/base.html' %}
+
+{% block content %}
+<h3>Release Notes</h3>
+<hr/>
+
+<h4>1.1.0</h4>
+<p><i>September 9, 2024</i></p>
+<ul>
+    <li>Update Django and other packages for security patches.</li>
+    <li>Update pymarc from version 4.2.2 to 5.2.2.</li>
+    <li>Fix display issues caused by pymarc changes.</li>
+    <li>Change deployment to require explicit version tag in all prod values files.</li>
+</ul>
+
+<h4>1.0.0</h4>
+<p><i>November 3, 2022</i></p>
+<ul>
+    <li>First production release.</li>
+</ul>
+
+{% endblock %}

--- a/voyager_archive/urls.py
+++ b/voyager_archive/urls.py
@@ -53,4 +53,5 @@ urlpatterns = [
         views.help,
         name="help",
     ),
+    path("release_notes/", views.release_notes, name="release_notes"),
 ]

--- a/voyager_archive/views.py
+++ b/voyager_archive/views.py
@@ -1,14 +1,36 @@
 import logging
+from django.http import HttpResponse
 from django.shortcuts import render, redirect
-from django.http.request import HttpRequest  # for code completion
-from django.http.response import HttpResponse
-from .views_utils import *
+from django.http.request import HttpRequest
+from voyager_archive.views_utils import (
+    get_auth_record,
+    get_bib_record,
+    get_inv_adjustment,
+    get_inv_adjustments,
+    get_inv_header_by_inv_id,
+    get_inv_headers,
+    get_inv_lines,
+    get_inv_lines_by_line_id,
+    get_item_by_id,
+    get_item_summary,
+    get_items,
+    get_mfhd_record,
+    get_mfhd_summary,
+    get_po_header_by_po_id,
+    get_po_headers,
+    get_po_lines,
+    get_po_lines_by_line_id,
+    get_search_form,
+    get_vendor_accts,
+    get_vendor_by_vendor_id,
+    get_vendors,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
-def search(request: HttpRequest) -> None:
+def search(request: HttpRequest) -> HttpResponse:
     if request.method == "POST":
         # Get form with search data from this request,
         # via utility function which also adds form
@@ -79,20 +101,20 @@ def search(request: HttpRequest) -> None:
         return render(request, "voyager_archive/search.html", context)
 
 
-def po_line_display(request: HttpRequest, po_line_item_id: int) -> None:
+def po_line_display(request: HttpRequest, po_line_item_id: int) -> HttpResponse:
     po_lines = get_po_lines_by_line_id(po_line_item_id)
     context = {"po_lines": po_lines}
     return render(request, "voyager_archive/po_line_display.html", context)
 
 
-def po_display(request: HttpRequest, po_id: int) -> None:
+def po_display(request: HttpRequest, po_id: int) -> HttpResponse:
     po_header = get_po_header_by_po_id(po_id)
     po_lines = get_po_lines(po_id)
     context = {"po_header": po_header, "po_lines": po_lines}
     return render(request, "voyager_archive/po_display.html", context)
 
 
-def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
+def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> HttpResponse:
     mfhd_summary = None
     item_summary = None
     if marc_type == "bib":
@@ -109,7 +131,7 @@ def marc_display(request: HttpRequest, marc_type: str, record_id: int) -> None:
     return render(request, "voyager_archive/marc_display.html", context)
 
 
-def invoice_display(request: HttpRequest, invoice_id: int) -> None:
+def invoice_display(request: HttpRequest, invoice_id: int) -> HttpResponse:
     inv_header = get_inv_header_by_inv_id(invoice_id)
     inv_lines = get_inv_lines(invoice_id)
     inv_adjustments = get_inv_adjustments(invoice_id)
@@ -121,30 +143,35 @@ def invoice_display(request: HttpRequest, invoice_id: int) -> None:
     return render(request, "voyager_archive/invoice_display.html", context)
 
 
-def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> None:
+def inv_line_display(request: HttpRequest, inv_line_item_id: int) -> HttpResponse:
     inv_lines = get_inv_lines_by_line_id(inv_line_item_id)
     context = {"inv_lines": inv_lines}
     return render(request, "voyager_archive/invoice_line_display.html", context)
 
 
-def inv_adj_display(request: HttpRequest, payment_id: int) -> None:
+def inv_adj_display(request: HttpRequest, payment_id: int) -> HttpResponse:
     inv_adjustment = get_inv_adjustment(payment_id)
     context = {"inv_adjustment": inv_adjustment}
     return render(request, "voyager_archive/invoice_adjustment_display.html", context)
 
 
-def item_display(request: HttpRequest, item_id: int) -> None:
+def item_display(request: HttpRequest, item_id: int) -> HttpResponse:
     item = get_item_by_id(item_id)
     context = {"item": item}
     return render(request, "voyager_archive/item_display.html", context)
 
 
-def vendor_display(request: HttpRequest, vendor_id: int) -> None:
+def vendor_display(request: HttpRequest, vendor_id: int) -> HttpResponse:
     vendor = get_vendor_by_vendor_id(vendor_id)
     vendor_accts = get_vendor_accts(vendor_id)
     context = {"vendor": vendor, "vendor_accts": vendor_accts}
     return render(request, "voyager_archive/vendor_display.html", context)
 
 
-def help(request: HttpRequest) -> None:
+def help(request: HttpRequest) -> HttpResponse:
     return render(request, "voyager_archive/help.html")
+
+
+def release_notes(request: HttpRequest) -> HttpResponse:
+    """Display release notes."""
+    return render(request, "voyager_archive/release_notes.html")

--- a/voyager_archive/views_utils.py
+++ b/voyager_archive/views_utils.py
@@ -98,7 +98,7 @@ def get_marc_fields(model_record: type[MARCRecordView]) -> dict:
             for delim in subfield_default_dict.keys():
                 subfield_dict[delim] = subfield_default_dict[delim]
             tmp_rec_dict["subfields"] = subfield_dict
-        except Exception as e:
+        except Exception:
             # If subfields don't exist an exception is thrown
             pass
 


### PR DESCRIPTION
Fixes [SYS-1677](https://uclalibrary.atlassian.net/browse/SYS-1677). Bumps version to `1.1.0` for deployment.

*_Requires a special deployment process - do not merge._*

This PR fixes a display bug caused by the move from PyMARC 4 to PyMARC 5.  Previously, `field.data`  was not defined for non-control fields, so our custom dictionary of fields didn't contain this attribute - which was fine for Django template output, since it just ignores undefined attributes like this.

With PyMARC 5 (specifically [this commit](https://gitlab.com/pymarc/pymarc/-/commit/6f88fc411d4890e399bcfa6378b75de3dc1e5606), all `Field` objects have `data` defined, and initialized to `None` for non-control fields.  This caused our template to display `None` incorrectly before the subfields of non-control fields.  Our bug is fixed now, by printing `data` only if it is not `None`.

This PR also changes the deployment process for the application.  Since a single image is built, but is deployed separately for each of our 3 Voyager archives, we previously tried to be clever by reading the version tag we use for deployment from `chart/values.yaml` instead of from all 3 (or 1 specific) production values files.  However, that means the Helm chart itself was being updated, requiring a parallel update to our [gitops repo](https://github.com/UCLALibrary/gitops_kubernetes/blob/main/apps/systems-team-prod-environment-values.yaml).

Since that's different from all of our other applications, and doesn't really save any work... I've switched to our standard process.  All 3 `charts/prod-*-values.yaml` files need `image.tag` updated, to stay in sync.  I added a section to `README.md` covering this.

This will require one last `gitops` update, which should be done closely together with the merge of this PR, so @ztucker4 , please do not merge this - just approve (if it qualifies, of course!)

Finally, I cleaned up some code in `views*.py` to make `flake8` happy, and I added release notes.




[SYS-1677]: https://uclalibrary.atlassian.net/browse/SYS-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ