### PR TITLE
SYS-1749: Update Django to 4.2.19 to patch security issues

### DIFF
--- a/charts/prod-ethnovoyagerarchive-values.yaml
+++ b/charts/prod-ethnovoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ftvavoyagerarchive-values.yaml
+++ b/charts/prod-ftvavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.16
+Django==4.2.19
 psycopg2==2.9.7
 gunicorn==23.0.0
 whitenoise==6.5.0

--- a/voyager_archive/templates/voyager_archive/release_notes.html
+++ b/voyager_archive/templates/voyager_archive/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.1</h4>
+<p><i>February 26, 2025</i></p>
+<ul>
+    <li>Update Django to 4.2.19 to patch security issues.</li>
+</ul>
+
 <h4>1.1.0</h4>
 <p><i>September 9, 2024</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-1749](https://uclalibrary.atlassian.net/browse/SYS-1749)

- Update Django to 4.2.19
- Bump version tag on all three production Helm charts
- Add release note

**Testing**
1/2 automated tests passed. The other test issued the following warning:

```
WARNINGS:
?: (staticfiles.W004) The directory '/home/django/voyager-archive/static' in the STATICFILES_DIRS setting does not exist.
```

Shall this be addressed in a new issue? Within my locally deployed Django container, it looks like the static directory is actually under `/home/django/voyager-archive/voyager-archive/static` (extra component in path).

[SYS-1749]: https://uclalibrary.atlassian.net/browse/SYS-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ