### PR TITLE
SYS-1831: Update Python, Django, and PostgreSQL

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -9,7 +9,7 @@
 ###
 
 # Used in settings.py
-DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
+DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
 DJANGO_DB_NAME=voyager_archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Debian repository management
 RUN apt-get update
@@ -6,7 +6,7 @@ RUN apt-get update
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg2 python module
+# Install dependencies needed to build psycopg python module
 RUN apt-get install -y gcc python3-dev libpq-dev
 
 # Create django user and switch context to that user

--- a/charts/prod-ethnovoyagerarchive-values.yaml
+++ b/charts/prod-ethnovoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.1
+  tag: 1.1.2
   pullPolicy: Always
 
 nameOverride: ""
@@ -43,7 +43,7 @@ django:
       - ethno-voy-archive.library.ucla.edu
     csrf_trusted_origins:
       - https://ethno-voy-archive.library.ucla.edu
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "ethno_voy_archive"
     db_user: "voy_archive_access"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/charts/prod-ftvavoyagerarchive-values.yaml
+++ b/charts/prod-ftvavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.1
+  tag: 1.1.2
   pullPolicy: Always
 
 nameOverride: ""
@@ -43,7 +43,7 @@ django:
       - ftva-voy-archive.library.ucla.edu
     csrf_trusted_origins:
       - https://ftva-voy-archive.library.ucla.edu
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "ftva_voy_archive"
     db_user: "voy_archive_access"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.1
+  tag: 1.1.2
   pullPolicy: Always
 
 nameOverride: ""
@@ -43,7 +43,7 @@ django:
       - ucla-voy-archive.library.ucla.edu
     csrf_trusted_origins:
       - https://ucla-voy-archive.library.ucla.edu
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "ucla_voy_archive"
     db_user: "voy_archive_access"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # For access to remote database via ssh tunnel on host
       - "host.docker.internal:host-gateway"
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker-compose_PGADMIN.yml
+++ b/docker-compose_PGADMIN.yml
@@ -15,7 +15,7 @@ services:
       # For access to remote database via ssh tunnel on host
       - "host.docker.internal:host-gateway"
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 
 # Check when database is ready for connections
 echo "Checking database connectivity..."
-until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+until python -c 'import os, psycopg ; conn = psycopg.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"
   sleep 5
 done

--- a/project/settings.py
+++ b/project/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
+
 import os
 from pathlib import Path
 
@@ -129,7 +130,7 @@ USE_TZ = True
 # Django will add this URL, and serve static files from here
 STATIC_URL = "/static/"
 # Where on the file system should Django find our custom static files?
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "voyager_archive/static")]
 # Where will all static files - our custom + Django's?
 # This matters only when not using runserver, and using collectstaticfiles.
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")

--- a/project/settings.py
+++ b/project/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
-
 import os
 from pathlib import Path
 
@@ -130,7 +129,7 @@ USE_TZ = True
 # Django will add this URL, and serve static files from here
 STATIC_URL = "/static/"
 # Where on the file system should Django find our custom static files?
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "voyager_archive/static")]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 # Where will all static files - our custom + Django's?
 # This matters only when not using runserver, and using collectstaticfiles.
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==4.2.19
-psycopg2==2.9.7
+Django==5.2.1
+psycopg==3.2.9
 gunicorn==23.0.0
 whitenoise==6.5.0
 pymarc==5.2.2

--- a/voyager_archive/templates/voyager_archive/release_notes.html
+++ b/voyager_archive/templates/voyager_archive/release_notes.html
@@ -3,6 +3,11 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.2</h4>
+<p><i>May 16, 2025</i></p>
+<ul>
+    <li>Update Django to 5.2.1 and Python to 3.13.</li>
+</ul>
 
 <h4>1.1.1</h4>
 <p><i>February 26, 2025</i></p>


### PR DESCRIPTION
Implements [SYS-1831](https://uclalibrary.atlassian.net/browse/SYS-1831)

Updates Python to 3.13, Django to 5.2.1, and PostgreSQL to 16.

This is a very straightforward upgrade. No code changes were needed to support the new Django version. The only "Log out" link is the default one found in the Admin interface, which works as expected.

### Testing
Drop old db volume(s)
`docker volume rm voyager-archive_pg_data`
`docker volume rm voyager-archive_pgadmin_data`

Build and bring up containers
`docker compose build`
`docker compose up -d`

Reload data
`sql_support/initialize_database.sh`

Run tests (2 total)
`docker compose exec django python manage.py test`

Check out [Application](http://127.0.0.1:8000/) and [Admin](http://127.0.0.1:8000/admin) in browser (default superuser: admin/admin)
Example bib record ID: 9411434

Bring up pgAdmin container
`docker compose -f docker-compose_PGADMIN.yml up -d`
Visit: http://localhost:5050/
Setup instructions available in README.md

[SYS-1831]: https://uclalibrary.atlassian.net/browse/SYS-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ