### PR TITLE
SYS-2134:update Django; tag bump and release notes for deployment

### DIFF
--- a/charts/prod-ethnovoyagerarchive-values.yaml
+++ b/charts/prod-ethnovoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.3
+  tag: 1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ftvavoyagerarchive-values.yaml
+++ b/charts/prod-ftvavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.3
+  tag: 1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-uclavoyagerarchive-values.yaml
+++ b/charts/prod-uclavoyagerarchive-values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: uclalibrary/voyager-archive
   # tag needs to be updated in all 3 prod-*-values.yaml files for deployment.
-  tag: 1.1.3
+  tag: 1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2.6
+Django==5.2.10
 psycopg==3.2.9
 gunicorn==23.0.0
 whitenoise==6.5.0

--- a/voyager_archive/templates/voyager_archive/release_notes.html
+++ b/voyager_archive/templates/voyager_archive/release_notes.html
@@ -3,6 +3,11 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.4</h4>
+<p><i>January 7, 2026</i></p>
+<ul>
+    <li>Update Django to 5.2.10.</li>
+</ul>
 
 <h4>1.1.3</h4>
 <p><i>September 19, 2025</i></p>


### PR DESCRIPTION
Implements [SYS-2134](https://uclalibrary.atlassian.net/browse/SYS-2134)

Updates Django to 5.2.10 to address all [Dependabot alerts](https://github.com/UCLALibrary/voyager-archive/security/dependabot). Note that for deployment, tag values are updated in all three `prod-values` chart files.

After rebuilding the container, run tests as below (should have 2 total). If desired, also check out the [app in browser](http://127.0.0.1:8000/). Search for Bib record ID 9411434 in the UCLA archive for a sample record.
`docker compose exec django python manage.py test`

[SYS-2134]: https://uclalibrary.atlassian.net/browse/SYS-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ